### PR TITLE
Add no changes to HResponse type

### DIFF
--- a/Example/HarborExample/ViewController.swift
+++ b/Example/HarborExample/ViewController.swift
@@ -43,6 +43,8 @@ final class ViewController: UIViewController {
             switch response {
             case .success(let result):
                 textAlert = result.quote
+            case .noChanges:
+                textAlert = "No Changes"
             case .cancelled:
                 textAlert = "Request Cancelled"
             case .error:

--- a/Sources/Harbor/HRequestManager.swift
+++ b/Sources/Harbor/HRequestManager.swift
@@ -72,6 +72,8 @@ extension HRequestManager {
                 } else {
                     return .error(.codableError)
                 }
+            case 304:
+                return .noChanges
             case 401:
                 if await !hasNewAuthorizationHeader(request: request) {
                     Self.config.authProvider?.authFailed()
@@ -152,6 +154,8 @@ extension HRequestManager {
             switch httpResponse.statusCode {
             case 200 ... 299:
                 return .success
+            case 304:
+                return .noChanges
             case 401:
                 if await !hasNewAuthorizationHeader(request: request) {
                     Self.config.authProvider?.authFailed()

--- a/Sources/Harbor/HResponse.swift
+++ b/Sources/Harbor/HResponse.swift
@@ -9,12 +9,14 @@ import Foundation
 
 public enum HResponse {
     case success
+    case noChanges
     case cancelled
     case error(HRequestError)
 }
 
 public enum HResponseWithResult<Model: Sendable>: Sendable {
     case success(Model)
+    case noChanges
     case cancelled
     case error(HRequestError)
 }


### PR DESCRIPTION
In this pull request, we introduce a new `noChanges` case to the `HResponse` enum. This case is used to represent scenarios where a request is successful, but the data has not changed since the last request.

The addition of this case provides several benefits:

1. **Efficiency**: By knowing that the data hasn't changed, we can avoid unnecessary data processing or UI updates. This can lead to performance improvements in our app.

2. **User Experience**: It allows us to provide more accurate feedback to the user. For example, we can display a "No new updates" message instead of silently doing nothing, which might confuse the user.

3. **Data Usage**: If our app operates in environments where data is costly or limited, knowing that there are no changes can help us minimize data usage by not downloading the same data repeatedly.

4. **Consistency**: It brings consistency to our response handling. Now, all possible outcomes of a request are represented in `HResponse`, making it easier for developers to understand and handle all possible scenarios.

By implementing this change, we aim to improve both the efficiency of our code and the experience of our users. It's a small change with significant impact.