### PR TITLE
Swift 6 Sendable compatibility + Single URL Session between calls 

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main", "release/1.0.0" ]
+    branches: [ "main", "release/*" ]
 
 jobs:
   build:

--- a/Example/HarborExample/Requests/JRPCRequest.swift
+++ b/Example/HarborExample/Requests/JRPCRequest.swift
@@ -9,13 +9,12 @@ import Foundation
 import HarborJRPC
 import Harbor
 
-struct JRPCRequest: HJRPCRequestProtocol, HDebugRequestProtocol {
+struct JRPCRequest: HJRPCRequestProtocol, HDebugRequestProtocol, @unchecked Sendable {
     var debugType: HDebugRequestType = .requestAndResponse
-
     typealias Model = String
     var method: String = "eth_blockNumber"
     var needsAuth: Bool = false
     var retries: Int? = nil
     var headers: [String : String]? = nil
-    var parameters: [String : Any]? = nil
+    var parameters: [String: Any]? = nil
 }

--- a/Example/HarborExample/RequestsView.swift
+++ b/Example/HarborExample/RequestsView.swift
@@ -13,7 +13,7 @@ struct RequestsView: View {
     @State private var showAlert = false
 
     init() {
-        HarborJRPC.setURL("https://rpc.ankr.com/eth")
+        Task { await HarborJRPC.setURL("https://rpc.ankr.com/eth") }
     }
 
     var body: some View {

--- a/Package.swift
+++ b/Package.swift
@@ -36,5 +36,5 @@ let package = Package(
             name: "HarborJRPCTests",
             dependencies: ["HarborJRPC"]),
     ],
-    swiftLanguageVersions: [.v5]
+    swiftLanguageVersions: [.version("6"), .v5]
 )

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Harbor is a library for making API requests in Swift in a simple way using async
 
 ## Requirements
 
-- Swift 5
+- Swift 5 (Swift 6 compatible)
 - iOS 15.0
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ You can include default headers in every request.
 To configure the default headers:
 
 ```swift
-Harbor.setDefaultHeaderParameters([
+await Harbor.setDefaultHeaderParameters([
     "MY_CUSTOM_HEADER": "VALUE"
 ])
 ```
@@ -117,7 +117,7 @@ class MyAuthProvider: HAuthProviderProtocol {
 After that, set your Auth provider:
 
 ```swift
-Harbor.setAuthProvider(MyAuthProvider())
+await Harbor.setAuthProvider(MyAuthProvider())
 ```
 
 If the request class has the `needsAuth` property set to `true`, Harbor will call the `getAuthorizationHeader` method of the authentication provider to get the `HAuthorizationHeader` instance to set it in the header before executing the request.
@@ -129,7 +129,7 @@ To set up mTLS, use the `setMTLS` method:
 
 ```swift
 let mTLS = HmTLS(p12FileUrl: yourP12FileUrl, password: "yourPassword")
-Harbor.setMTLS(mTLS)
+await Harbor.setMTLS(mTLS)
 ```
 
 #### SSL Pinning
@@ -139,7 +139,7 @@ To configure SSL Pinning, use the `setSSlPinningSHA256` method:
 
 ```swift
 let sslPinningSHA256 = "yourSHA256CertificateHash"
-Harbor.setSSlPinningSHA256(sslPinningSHA256)
+await Harbor.setSSlPinningSHA256(sslPinningSHA256)
 ```
 
 ### Request Protocols

--- a/Sources/Harbor/HAuthProviderProtocol.swift
+++ b/Sources/Harbor/HAuthProviderProtocol.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-public protocol HAuthProviderProtocol {
+public protocol HAuthProviderProtocol: Sendable {
     func getAuthorizationHeader() async -> HAuthorizationHeader
     func authFailed() async
 }
 
-public struct HAuthorizationHeader {
+public struct HAuthorizationHeader: Sendable {
     public let key: String
     public let value: String
 

--- a/Sources/Harbor/HAuthProviderProtocol.swift
+++ b/Sources/Harbor/HAuthProviderProtocol.swift
@@ -12,7 +12,7 @@ public protocol HAuthProviderProtocol: Sendable {
     func authFailed() async
 }
 
-public struct HAuthorizationHeader: Sendable {
+public struct HAuthorizationHeader: Sendable, Equatable {
     public let key: String
     public let value: String
 

--- a/Sources/Harbor/HConfig.swift
+++ b/Sources/Harbor/HConfig.swift
@@ -7,9 +7,12 @@
 
 import Foundation
 
+@HRequestManagerActor
 struct HConfig: Sendable {
     var authProvider: HAuthProviderProtocol?
     var defaultHeaderParameters: [String: String]?
     var mTLS: HmTLS?
     var sslPinningSHA256: String?
+    let defaultSession: URLSession = URLSession.shared
+    var currentSession: URLSession?
 }

--- a/Sources/Harbor/HConfig.swift
+++ b/Sources/Harbor/HConfig.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct HConfig {
+struct HConfig: Sendable {
     var authProvider: HAuthProviderProtocol?
     var defaultHeaderParameters: [String: String]?
     var mTLS: HmTLS?

--- a/Sources/Harbor/HDebugRequestProtocol.swift
+++ b/Sources/Harbor/HDebugRequestProtocol.swift
@@ -11,7 +11,7 @@ public protocol HDebugRequestProtocol {
     var debugType: HDebugRequestType { get set }
 }
 
-public enum HDebugRequestType {
+public enum HDebugRequestType: Sendable {
     case none
     case request
     case response

--- a/Sources/Harbor/HRequestManager.swift
+++ b/Sources/Harbor/HRequestManager.swift
@@ -16,13 +16,6 @@ import SystemConfiguration
 @HRequestManagerActor
 internal final class HRequestManager: Sendable {
     internal static var config: HConfig = HConfig()
-
-    private static let defaultSession: URLSession = URLSession.shared
-    private static var currentSession: URLSession?
-
-    internal static func configureSession(_ session: URLSession?) {
-        currentSession = session
-    }
 }
 
 // MARK: - Request With Result
@@ -336,7 +329,7 @@ internal extension HRequestManager {
 
     /// Session getter that handles mTLS and SSL pinning if needed
     private static func getSession() -> URLSession {
-        if let currentSession {
+        if let currentSession = config.currentSession {
             return currentSession
         }
 
@@ -344,12 +337,12 @@ internal extension HRequestManager {
         if config.mTLS != nil || config.sslPinningSHA256 != nil {
             let sessionDelegate = HURLSessionDelegate(mTLS: config.mTLS, sslPinningSHA256: config.sslPinningSHA256)
             let newSession = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
-            currentSession = newSession
+            config.currentSession = newSession
             return newSession
         }
 
         // Otherwise use the default shared session
-        return defaultSession
+        return config.defaultSession
     }
 }
 

--- a/Sources/Harbor/HRequestManager.swift
+++ b/Sources/Harbor/HRequestManager.swift
@@ -26,7 +26,7 @@ internal final class HRequestManager: Sendable {
 
     /// Session getter that handles mTLS and SSL pinning if needed
     private static func getSession() -> URLSession {
-        if let currentSession = currentSession {
+        if let currentSession {
             return currentSession
         }
 

--- a/Sources/Harbor/HRequestProtocol.swift
+++ b/Sources/Harbor/HRequestProtocol.swift
@@ -35,8 +35,8 @@ public extension HRequestWithEmptyResponseProtocol {
 }
 
 // MARK: - Request with Result Protocol
-public protocol HRequestWithResultProtocol: HRequestBaseRequestProtocol where Model: Sendable {
-    associatedtype Model: Codable
+public protocol HRequestWithResultProtocol: HRequestBaseRequestProtocol {
+    associatedtype Model: Codable & Sendable
     func parseData<Model: Codable> (data: Data, model: Model.Type) throws -> Model
     func request() async -> HResponseWithResult<Model>
 }

--- a/Sources/Harbor/HRequestProtocol.swift
+++ b/Sources/Harbor/HRequestProtocol.swift
@@ -14,7 +14,7 @@ public enum HRequestDataType {
 }
 
 // MARK: - Base Protocol
-public protocol HRequestBaseRequestProtocol {
+public protocol HRequestBaseRequestProtocol: Sendable {
     var url: String { get }
     var httpMethod: HHttpMethod { get }
     var needsAuth: Bool { get }
@@ -35,7 +35,7 @@ public extension HRequestWithEmptyResponseProtocol {
 }
 
 // MARK: - Request with Result Protocol
-public protocol HRequestWithResultProtocol: HRequestBaseRequestProtocol {
+public protocol HRequestWithResultProtocol: HRequestBaseRequestProtocol where Model: Sendable {
     associatedtype Model: Codable
     func parseData<Model: Codable> (data: Data, model: Model.Type) throws -> Model
     func request() async -> HResponseWithResult<Model>

--- a/Sources/Harbor/HRequestProtocol.swift
+++ b/Sources/Harbor/HRequestProtocol.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 // MARK: - Request Data Type
-public enum HRequestDataType {
+public enum HRequestDataType: Sendable {
     case json
     case multipart
 }

--- a/Sources/Harbor/Harbor.swift
+++ b/Sources/Harbor/Harbor.swift
@@ -27,4 +27,8 @@ public final class Harbor: Sendable {
     public static func setSSlPinningSHA256(_ sslPinningSHA256: String?) {
         HRequestManager.config.sslPinningSHA256 = sslPinningSHA256
     }
+
+    public static func setCustomSession(_ customSession: URLSession) {
+        HRequestManager.configureSession(customSession)
+    }
 }

--- a/Sources/Harbor/Harbor.swift
+++ b/Sources/Harbor/Harbor.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-public final class Harbor {
+@HRequestManagerActor
+public final class Harbor: Sendable {
 
     private init() {}
 

--- a/Sources/Harbor/Harbor.swift
+++ b/Sources/Harbor/Harbor.swift
@@ -29,6 +29,6 @@ public final class Harbor: Sendable {
     }
 
     public static func setCustomSession(_ customSession: URLSession) {
-        HRequestManager.configureSession(customSession)
+        HRequestManager.config.currentSession = customSession
     }
 }

--- a/Sources/Harbor/HmTLS.swift
+++ b/Sources/Harbor/HmTLS.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct HmTLS {
+public struct HmTLS: Sendable {
     let p12FileUrl: URL
     let password: String
 

--- a/Sources/HarborJRPC/HJRPCConfig.swift
+++ b/Sources/HarborJRPC/HJRPCConfig.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct HJRPCConfig {
+struct HJRPCConfig: Sendable {
     var url: String = ""
     var jrpcVersion: String = "2.0"
 }

--- a/Sources/HarborJRPC/HJRPCRequestManager.swift
+++ b/Sources/HarborJRPC/HJRPCRequestManager.swift
@@ -8,17 +8,18 @@
 import Foundation
 import Harbor
 
+@HRequestManagerActor
 final class HJRPCRequestManager {
     static var config: HJRPCConfig = HJRPCConfig()
 }
 
 extension HJRPCRequestManager {
     static func request<Model: Codable>(model: Model.Type, request: any HJRPCRequestProtocol) async -> HJRPCResponse<Model> {
-        guard !request.url.isEmpty else {
+        guard !config.url.isEmpty else {
             return .error(.urlNeeded)
         }
 
-        let harborRequest = request.wrapRequest(type: model)
+        let harborRequest: HJRPCRequestWrapper = request.wrapRequest(type: model)
         let response: HResponseWithResult = await harborRequest.request()
 
         switch response {

--- a/Sources/HarborJRPC/HJRPCRequestProtocol.swift
+++ b/Sources/HarborJRPC/HJRPCRequestProtocol.swift
@@ -9,7 +9,7 @@ import Foundation
 import Harbor
 
 public protocol HJRPCRequestProtocol: Sendable {
-    associatedtype Model: Codable
+    associatedtype Model: Codable & Sendable
     var method: String { get }
     var needsAuth: Bool { get }
     var retries: Int? { get set}
@@ -20,7 +20,7 @@ public protocol HJRPCRequestProtocol: Sendable {
 }
 
 public extension HJRPCRequestProtocol {
-    func request() async -> HJRPCResponse<Model> where Model: Sendable {
+    func request() async -> HJRPCResponse<Model> {
         return await HJRPCRequestManager.request(model: Model.self, request: self)
     }
 }

--- a/Sources/HarborJRPC/HJRPCRequestProtocol.swift
+++ b/Sources/HarborJRPC/HJRPCRequestProtocol.swift
@@ -42,7 +42,7 @@ extension HJRPCRequestProtocol {
     }
 }
 
-struct HJRPCRequestWrapper<Model: Codable>: @unchecked Sendable, HPostRequestProtocol, HRequestWithResultProtocol where Model: Sendable {
+struct HJRPCRequestWrapper<Model: Codable & Sendable>: @unchecked Sendable, HPostRequestProtocol, HRequestWithResultProtocol {
     var debugType: HDebugRequestType
     typealias Model = HJRPCResult<Model>
     var bodyType: HRequestDataType = .json

--- a/Sources/HarborJRPC/HJSONRPCResponse.swift
+++ b/Sources/HarborJRPC/HJSONRPCResponse.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct HJRPCResult<Model: Codable>: Codable {
+struct HJRPCResult<Model: Codable>: Codable, Sendable where Model: Sendable {
     let id: String?
     let result: Model?
     let error: HJRPCError?

--- a/Sources/HarborJRPC/HJSONRPCResponse.swift
+++ b/Sources/HarborJRPC/HJSONRPCResponse.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct HJRPCResult<Model: Codable>: Codable, Sendable where Model: Sendable {
+struct HJRPCResult<Model: Codable & Sendable>: Codable, Sendable {
     let id: String?
     let result: Model?
     let error: HJRPCError?

--- a/Sources/HarborJRPC/HarborJRPC.swift
+++ b/Sources/HarborJRPC/HarborJRPC.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+import Harbor
 
+@HRequestManagerActor
 public final class HarborJRPC {
     private init() {}
 

--- a/Tests/HarborJRPCTests/HarborJRPCTests.swift
+++ b/Tests/HarborJRPCTests/HarborJRPCTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 final class HarborJRPCTests: XCTestCase {
 
-    override class func setUp() {
-        HarborJRPC.setURL("https://rpc.ankr.com/eth")
+    override func setUp() async throws {
+        await HarborJRPC.setURL("https://rpc.ankr.com/eth")
     }
 
     func testRequestSuccess() async throws {
@@ -43,13 +43,13 @@ final class HarborJRPCTests: XCTestCase {
     }
 }
 
-struct TestRequest: HJRPCRequestProtocol {
+struct TestRequest: HJRPCRequestProtocol, @unchecked Sendable {
     typealias Model = String
     var method: String = "eth_blockNumber"
     var needsAuth: Bool = false
     var retries: Int? = nil
     var headers: [String : String]? = nil
-    var parameters: [String : Any]? = nil
+    var parameters: [String: Any]? = nil
 
     init(method: String, parameters: [String : Any]? = nil) {
         self.method = method

--- a/Tests/HarborTests/HarborBodyTests.swift
+++ b/Tests/HarborTests/HarborBodyTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import Harbor
 
+@HRequestManagerActor
 final class HarborBodyTests: XCTestCase {
 
     func testBuildRequestWithMultipartBodyType() throws {

--- a/Tests/HarborTests/HarborRequestManagerAuthTests.swift
+++ b/Tests/HarborTests/HarborRequestManagerAuthTests.swift
@@ -1,0 +1,76 @@
+//
+//  HarborRequestManagerAuthTests.swift
+//  Harbor
+//
+//  Created by Jalil on 05/11/24.
+//
+
+import XCTest
+@testable import Harbor
+
+private final class MockAuthProvider: HAuthProviderProtocol {
+    func getAuthorizationHeader() async -> HAuthorizationHeader {
+        return HAuthorizationHeader(key: "Authorization", value: "Bearer mock_token")
+    }
+
+    func authFailed() async {
+        // Handle auth failure logic if needed.
+    }
+}
+
+extension HRequestError: Equatable {
+    public static func ==(lhs: HRequestError, rhs: HRequestError) -> Bool {
+        switch (lhs, rhs) {
+        case (.authProviderNeeded, .authProviderNeeded):
+            return true
+        case (.noConnectionError, .noConnectionError):
+            return true
+        case (.malformedRequestError, .malformedRequestError):
+            return true
+        case (.timeoutError, .timeoutError):
+            return true
+        case (.invalidHttpResponse, .invalidHttpResponse):
+            return true
+        case (.codableError(let lhsModel, _), .codableError(let rhsModel, _)):
+            return lhsModel == rhsModel
+        case (.apiError(let lhsStatusCode, _), .apiError(let rhsStatusCode, _)):
+            return lhsStatusCode == rhsStatusCode
+        default:
+            return false
+        }
+    }
+}
+
+@HRequestManagerActor
+final class HarborRequestManagerAuthTests: XCTestCase {
+
+    func testAddAuthCredentialsIfNeededWithAuthSuccess() async throws {
+        // Given
+        let mockAuthProvider = MockAuthProvider()
+        HRequestManager.config = HConfig(authProvider: mockAuthProvider)
+
+        let mockRequest = MockGetRequestService(needsAuth: true, url: "https://example.com/mock_endpoint")
+
+        // When
+        let modifiedRequest = await HRequestManager.addAuthCredentialsIfNeeded(mockRequest)
+
+        // Then
+        XCTAssertNotNil(modifiedRequest, "Expected modified request with auth credentials")
+        XCTAssertEqual(modifiedRequest?.headerParameters?["Authorization"], "Bearer mock_token", "Expected authorization header to be set correctly")
+    }
+
+    func testAddAuthCredentialsIfNeededWithoutAuth() async throws {
+        // Given
+        let mockAuthProvider = MockAuthProvider()
+        HRequestManager.config = HConfig(authProvider: mockAuthProvider)
+
+        let mockRequest = MockGetRequestService(needsAuth: false, url: "https://example.com/mock_endpoint")
+
+        // When
+        let modifiedRequest = await HRequestManager.addAuthCredentialsIfNeeded(mockRequest)
+
+        // Then
+        XCTAssertNotNil(modifiedRequest, "Expected original request since auth is not needed")
+        XCTAssertNil(modifiedRequest?.headerParameters?["Authorization"], "Expected no authorization header since auth is not needed")
+    }
+}

--- a/Tests/HarborTests/HarborTests.swift
+++ b/Tests/HarborTests/HarborTests.swift
@@ -3,36 +3,36 @@ import XCTest
 
 final class HarborTests: XCTestCase {
 
-    func testShouldAddSinglePathParameterCorrectlyToURL() throws {
+    func testShouldAddSinglePathParameterCorrectlyToURL() async throws {
         // Given
         let baseUrl = "https://api.github.com/users/{USER}/"
         let expectedURL = "https://api.github.com/users/OmarJalil/"
 
         // When
-        let url = HRequestManager.compositeURL(url: baseUrl, pathParameters: ["USER": "OmarJalil"], queryParameters: nil)
+        let url = await HRequestManager.compositeURL(url: baseUrl, pathParameters: ["USER": "OmarJalil"], queryParameters: nil)
 
         // Then
         XCTAssertEqual(expectedURL, url?.absoluteString)
     }
 
-    func testShouldAddMultiplePathParametersCorrectlyToURL() throws {
+    func testShouldAddMultiplePathParametersCorrectlyToURL() async throws {
         // Given
         let baseUrl = "https://api.github.com/users/{USER}/following/{FOLLOWS}/"
         let expectedURL = "https://api.github.com/users/OmarJalil/following/javiermanzo/"
 
         // When
-        let url = HRequestManager.compositeURL(url: baseUrl, pathParameters: ["FOLLOWS": "javiermanzo", "USER": "OmarJalil"], queryParameters: nil)
+        let url = await HRequestManager.compositeURL(url: baseUrl, pathParameters: ["FOLLOWS": "javiermanzo", "USER": "OmarJalil"], queryParameters: nil)
 
         // Then
         XCTAssertEqual(expectedURL, url?.absoluteString)
     }
 
-    func testBuildGetRequest() {
+    func testBuildGetRequest() async throws {
         // Given
         let service = MockGetRequestService(url: "https://example.com", queryParameters: ["id": "123", "sort": "desc"])
 
         // When
-        let request = HRequestManager.buildUrlRequest(request: service)
+        let request = await HRequestManager.buildUrlRequest(request: service)
         
         // Then
         XCTAssertNotNil(request)
@@ -40,27 +40,28 @@ final class HarborTests: XCTestCase {
         XCTAssertEqual(request?.httpMethod, "GET")
     }
 
-    func testBuildPostRequest() {
+    func testBuildPostRequest() async throws {
         // Given
         let service = MockPostRequestService(url: "https://example.com", bodyParameters: ["name": "John"])
 
         // When
-        let request = HRequestManager.buildUrlRequest(request: service)
+        let request = await HRequestManager.buildUrlRequest(request: service)
 
         // Then
         XCTAssertNotNil(request)
         XCTAssertEqual(request?.url?.absoluteString, "https://example.com")
         XCTAssertEqual(request?.httpMethod, "POST")
         XCTAssertEqual(request?.allHTTPHeaderFields?["Content-Type"], "application/json")
-        XCTAssertEqual(request?.httpBody, HRequestManager.dataBody(params: ["name": "John"], type: .json))
+        let httpBody = await HRequestManager.dataBody(params: ["name": "John"], type: .json)
+        XCTAssertEqual(request?.httpBody, httpBody)
     }
 
-    func testBuildInvalidRequest() {
+    func testBuildInvalidRequest() async throws {
         // Given
         let service = MockInvalidRequestService()
 
         // When
-        let request = HRequestManager.buildUrlRequest(request: service)
+        let request = await HRequestManager.buildUrlRequest(request: service)
 
         // Then
         XCTAssertNil(request)

--- a/Tests/HarborTests/Mocks/MocksRequest.swift
+++ b/Tests/HarborTests/Mocks/MocksRequest.swift
@@ -7,7 +7,7 @@
 
 import Harbor
 
-final class MockGetRequestService: HGetRequestProtocol {
+final class MockGetRequestService: HGetRequestProtocol, @unchecked Sendable {
 
     typealias Model = String
     var headerParameters: [String: String]?
@@ -27,7 +27,7 @@ final class MockGetRequestService: HGetRequestProtocol {
     }
 }
 
-final class MockPostRequestService: HPostRequestProtocol {
+final class MockPostRequestService: HPostRequestProtocol, @unchecked Sendable {
     var headerParameters: [String: String]?
     var needsAuth: Bool
     var retries: Int?
@@ -48,7 +48,7 @@ final class MockPostRequestService: HPostRequestProtocol {
     }
 }
 
-final class MockPostBodyRequestService: HPostRequestProtocol {
+final class MockPostBodyRequestService: HPostRequestProtocol, @unchecked Sendable {
     var headerParameters: [String: String]?
     var needsAuth: Bool
     var retries: Int?
@@ -68,7 +68,7 @@ final class MockPostBodyRequestService: HPostRequestProtocol {
     }
 }
 
-final class MockInvalidRequestService: HRequestBaseRequestProtocol {
+final class MockInvalidRequestService: HRequestBaseRequestProtocol, @unchecked Sendable {
     var headerParameters: [String: String]?
     var url: String
     var needsAuth: Bool = false


### PR DESCRIPTION
This PR tracks the implementation of full concurrency checking when building in Swift 6 mode. 

Implementation Details
This PR consists of Sendable annotations, with a few logic changes to fix actual safety issues.
Also it includes a small change regarding the use of URLSession, now allowing to inject a custom URLSession, and use a default one instead of creating a new one on each request. 

Testing Details 
Tests updated with needed annotations.