### PR TITLE
Fix URL injection vulnerability in HURLBuilder

### DIFF
--- a/Sources/Harbor/Utils/HURLBuilder.swift
+++ b/Sources/Harbor/Utils/HURLBuilder.swift
@@ -21,7 +21,8 @@ struct HURLBuilder {
 
         if let pathParameters {
             for (key, value) in pathParameters {
-                compositeUrl = compositeUrl.replacingOccurrences(of: "{\(key)}", with: value)
+                let encodedValue = value.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? value
+                compositeUrl = compositeUrl.replacingOccurrences(of: "{\(key)}", with: encodedValue)
             }
         }
 

--- a/Tests/HarborTests/HURLBuilderTests.swift
+++ b/Tests/HarborTests/HURLBuilderTests.swift
@@ -1,0 +1,34 @@
+//
+//  HURLBuilderTests.swift
+//  Harbor
+//
+//  Created by Javier Manzo on 08/07/2025.
+//
+
+import XCTest
+@testable import Harbor
+
+final class HURLBuilderTests: XCTestCase {
+
+    func testPathParameterEncoding() {
+        let baseUrl = "https://api.example.com/users/{id}/details"
+        // '?' should be encoded to prevent query injection
+        // '/' is allowed in urlPathAllowed so it might remain depending on the implementation details,
+        // but '?' is definitely not allowed in path without encoding if we want it to be part of the segment.
+        let pathParameters = ["id": "user?name=test"]
+        
+        let url = HURLBuilder.compositeURL(url: baseUrl, pathParameters: pathParameters)
+        
+        // We expect '?' to be encoded as %3F
+        XCTAssertEqual(url?.absoluteString, "https://api.example.com/users/user%3Fname=test/details")
+    }
+
+    func testPathParameterSimple() {
+        let baseUrl = "https://api.example.com/users/{id}"
+        let pathParameters = ["id": "123"]
+        
+        let url = HURLBuilder.compositeURL(url: baseUrl, pathParameters: pathParameters)
+        
+        XCTAssertEqual(url?.absoluteString, "https://api.example.com/users/123")
+    }
+}


### PR DESCRIPTION
## Summary
- Applied `.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)` to path parameters in `HURLBuilder` to prevent URL injection.
- Added unit tests to verify proper encoding.

## Test plan
- Run `swift test --filter HURLBuilderTests` to verify the fix.
- Verify that standard requests with path parameters still work.