### PR TITLE
Optimize Cache Cleanup Performance

### DIFF
--- a/Sources/Harbor/Cache/HCacheManager.swift
+++ b/Sources/Harbor/Cache/HCacheManager.swift
@@ -46,7 +46,7 @@ extension HCache {
             
             // 4. Perform background cleanup
             let dir = self.cacheDirectory
-            diskQueue.async {
+            Task.detached(priority: .background) {
                 FileStorage.cleanupExpiredFiles(at: dir)
             }
         }


### PR DESCRIPTION
## Summary
Moves the cache cleanup process to a detached background task to prevent blocking the initialization of the `HCacheManager`, which typically occurs during app launch.

## Motivation
Previously, `cleanupExpiredFiles` was dispatched to `diskQueue` in `init`. Since `diskQueue` is also used for cache lookups, a slow cleanup could block initial cache requests. Additionally, moving this to a background task ensures minimal impact on the main thread and other critical startup operations.

## Changes
- Wrapped `FileStorage.cleanupExpiredFiles` in `Task.detached(priority: .background)`.

## Notes
- Partial reading of files was considered but requires a file format migration to be fully effective without reading the JSON payload. This change focuses on the threading model for immediate performance gain.