### PR TITLE
Enhance logging security and control in Release builds

### DIFF
--- a/Sources/Harbor/Config/HConfig.swift
+++ b/Sources/Harbor/Config/HConfig.swift
@@ -15,7 +15,7 @@ struct HConfig: Sendable {
     var sslPinningKeys: [String]?
     var currentURLSession: URLSession?
     var mocksOnlyInDebug: Bool = true
-    var isLoggingEnabled: Bool = true
+    var isLoggingEnabled: Bool = false
     var defaultCacheConfiguration: HCache.Configuration = .enabled(expirationTime: .oneWeek)
     var defaultMemoryCacheCapacity: Int = 100
     var defaultStartUpMemoryCacheCapacity: Int = 50

--- a/Sources/Harbor/Config/HConfig.swift
+++ b/Sources/Harbor/Config/HConfig.swift
@@ -15,6 +15,7 @@ struct HConfig: Sendable {
     var sslPinningKeys: [String]?
     var currentURLSession: URLSession?
     var mocksOnlyInDebug: Bool = true
+    var isLoggingEnabled: Bool = true
     var defaultCacheConfiguration: HCache.Configuration = .enabled(expirationTime: .oneWeek)
     var defaultMemoryCacheCapacity: Int = 100
     var defaultStartUpMemoryCacheCapacity: Int = 50

--- a/Sources/Harbor/Debug/HDebugRequestProtocol.swift
+++ b/Sources/Harbor/Debug/HDebugRequestProtocol.swift
@@ -42,7 +42,7 @@ public enum HDebugRequestType: Sendable {
 }
 
 @HRequestManagerActor
-public extension HDebugRequestProtocol {
+extension HDebugRequestProtocol {
     
     /// Shared logger instance for debug output using LogBird framework.
     /// Uses "com.harbor" subsystem with "debugging" category for organized log filtering.
@@ -50,7 +50,9 @@ public extension HDebugRequestProtocol {
     
     /// Prints detailed request information to the console.
     /// - Parameter urlRequest: The URL request to debug.
-    func printRequest(urlRequest: URLRequest) {
+    func logRequest(urlRequest: URLRequest) {
+        #if DEBUG
+        guard HRequestManager.config.isLoggingEnabled else { return }
         if let request = self as? HRequestBaseRequestProtocol,
            self.debugType == .request || self.debugType == .requestAndResponse {
             var additionalInfo: [String: String] = [:]
@@ -83,6 +85,7 @@ public extension HDebugRequestProtocol {
             
             Self.logger.log("Request \(String(describing: type(of: request)))", extraMessages: extraMessages, additionalInfo: additionalInfo, level: .debug)
         }
+        #endif
     }
     
     /// Prints detailed response information to the console.
@@ -90,7 +93,9 @@ public extension HDebugRequestProtocol {
     ///   - httpResponse: The HTTP response received.
     ///   - data: The response data.
     ///   - duration: The request duration in milliseconds.
-    func printResponse(httpResponse: HTTPURLResponse, data: Data, duration: Double) {
+    func logResponse(httpResponse: HTTPURLResponse, data: Data, duration: Double) {
+        #if DEBUG
+        guard HRequestManager.config.isLoggingEnabled else { return }
         if self.debugType == .response || self.debugType == .requestAndResponse {
             var extraMessages: [LBExtraMessage] = []
             if let value = String(data: data, encoding: String.Encoding.ascii) {
@@ -106,11 +111,14 @@ public extension HDebugRequestProtocol {
             
             Self.logger.log("Response \(String(describing: type(of: self)))", extraMessages: extraMessages, additionalInfo: additionalInfo, level: .debug)
         }
+        #endif
     }
     
     /// Prints error response information to the console.
     /// - Parameter error: The error that occurred during the request.
-    func printErrorResponse(error: HRequestError) {
+    func logErrorResponse(error: HRequestError) {
+        #if DEBUG
+        guard HRequestManager.config.isLoggingEnabled else { return }
         if self.debugType == .response || self.debugType == .requestAndResponse {
             var extraMessages: [LBExtraMessage] = []
             
@@ -121,6 +129,7 @@ public extension HDebugRequestProtocol {
             
             Self.logger.log("Response Error \(String(describing: type(of: self)))", extraMessages: extraMessages, additionalInfo: additionalInfo, level: .error)
         }
+        #endif
     }
     
     /// Converts a dictionary to a JSON string representation.
@@ -133,7 +142,11 @@ public extension HDebugRequestProtocol {
             let jsonString = String(data: jsonData, encoding: .utf8)
             return jsonString
         } catch {
-            Self.logger.log("Error converting dictionary to JSON", error: error)
+            #if DEBUG
+            if HRequestManager.config.isLoggingEnabled {
+                Self.logger.log("Error converting dictionary to JSON", error: error)
+            }
+            #endif
             return nil
         }
     }

--- a/Sources/Harbor/Harbor.swift
+++ b/Sources/Harbor/Harbor.swift
@@ -31,7 +31,7 @@ public extension Harbor {
 
     /// Configures mutual TLS for client certificate authentication.
     static func setMTLS(_ mTLS: HmTLS?) {
-        HRequestManager.config.mTLSIdentity = mTLS?.extractIdentity()
+        HRequestManager.config.mTLSIdentity = mTLS?.extractIdentity(loggingEnabled: HRequestManager.config.isLoggingEnabled)
     }
 
     /// Enables SSL pinning with SHA256 certificate hash.
@@ -69,6 +69,12 @@ public extension Harbor {
     /// Configures whether mocks are only active in DEBUG builds.
     static func setMocksOnlyInDebug(_ value: Bool) {
         HRequestManager.config.mocksOnlyInDebug = value
+    }
+
+    /// Configures whether debug logs are enabled.
+    /// - Parameter enabled: If true, logs will be printed (subject to #if DEBUG). If false, no logs will be printed.
+    static func setLoggingEnabled(_ enabled: Bool) {
+        HRequestManager.config.isLoggingEnabled = enabled
     }
 }
 

--- a/Sources/Harbor/Request/HRequestManager.swift
+++ b/Sources/Harbor/Request/HRequestManager.swift
@@ -62,7 +62,7 @@ extension HRequestManager {
         }
 
         if let request = request as? HDebugRequestProtocol {
-            request.printRequest(urlRequest: urlRequest)
+            request.logRequest(urlRequest: urlRequest)
         }
 
         do {
@@ -87,7 +87,7 @@ extension HRequestManager {
             }
 
             if let request = request as? HDebugRequestProtocol {
-                request.printResponse(httpResponse: httpResponse, data: data, duration: duration)
+                request.logResponse(httpResponse: httpResponse, data: data, duration: duration)
             }
 
             return await processResponse(model: model,
@@ -203,7 +203,7 @@ extension HRequestManager {
         }
 
         if let request = request as? HDebugRequestProtocol {
-            request.printRequest(urlRequest: urlRequest)
+            request.logRequest(urlRequest: urlRequest)
         }
 
         do {
@@ -228,7 +228,7 @@ extension HRequestManager {
             }
 
             if let request = request as? HDebugRequestProtocol {
-                request.printResponse(httpResponse: httpResponse, data: data, duration: duration)
+                request.logResponse(httpResponse: httpResponse, data: data, duration: duration)
             }
 
             return await processResponse(request: request, statusCode: httpResponse.statusCode, data: data)
@@ -423,7 +423,7 @@ extension HRequestManager {
 
     static func logError(_ error: HRequestError, request: HRequestBaseRequestProtocol) {
         if let request = request as? HDebugRequestProtocol {
-            request.printErrorResponse(error: error)
+            request.logErrorResponse(error: error)
         }
     }
 }

--- a/Sources/Harbor/Request/HmTLS.swift
+++ b/Sources/Harbor/Request/HmTLS.swift
@@ -34,10 +34,10 @@ public struct HmTLS: Sendable {
         self.password = password
     }
     
-    func extractIdentity() -> HMTLSIdentity? {
+    func extractIdentity(loggingEnabled: Bool = true) -> HMTLSIdentity? {
         do {
             let p12Data = try Data(contentsOf: p12FileUrl)
-            let p12Contents = PKCS12(p12Data: p12Data, password: password)
+            let p12Contents = PKCS12(p12Data: p12Data, password: password, loggingEnabled: loggingEnabled)
 
             if let identity = p12Contents.identity {
                 return HMTLSIdentity(identity: identity)

--- a/Sources/Harbor/Request/HmTLS.swift
+++ b/Sources/Harbor/Request/HmTLS.swift
@@ -34,7 +34,7 @@ public struct HmTLS: Sendable {
         self.password = password
     }
     
-    func extractIdentity(loggingEnabled: Bool = true) -> HMTLSIdentity? {
+    func extractIdentity(loggingEnabled: Bool = false) -> HMTLSIdentity? {
         do {
             let p12Data = try Data(contentsOf: p12FileUrl)
             let p12Contents = PKCS12(p12Data: p12Data, password: password, loggingEnabled: loggingEnabled)

--- a/Sources/Harbor/Utils/PKCS12.swift
+++ b/Sources/Harbor/Utils/PKCS12.swift
@@ -17,8 +17,10 @@ final class PKCS12 {
     var trust: SecTrust?
     var certChain: [SecTrust]?
     var identity: SecIdentity?
+    var loggingEnabled: Bool
 
-    init(p12Data: Data, password: String) {
+    init(p12Data: Data, password: String, loggingEnabled: Bool = true) {
+        self.loggingEnabled = loggingEnabled
         let importPasswordOption: NSDictionary = [kSecImportExportPassphrase as NSString: password]
 
         var items: CFArray?
@@ -27,20 +29,32 @@ final class PKCS12 {
 
         guard status == errSecSuccess else {
             if status == errSecAuthFailed {
-                Self.logger.log("PKCS12: Incorrect password")
+                #if DEBUG
+                if loggingEnabled {
+                    Self.logger.log("PKCS12: Incorrect password")
+                }
+                #endif
             }
             return
         }
 
         guard let theItemsCFArray = items else {
-            Self.logger.log("PKCS12: error loading items")
+            #if DEBUG
+            if loggingEnabled {
+                Self.logger.log("PKCS12: error loading items")
+            }
+            #endif
             return
         }
         
         let theItemsNSArray: NSArray = theItemsCFArray as NSArray
 
         guard let dictArray = theItemsNSArray as? [[String: AnyObject]] else {
-            Self.logger.log("PKCS12: error loading items")
+            #if DEBUG
+            if loggingEnabled {
+                Self.logger.log("PKCS12: error loading items")
+            }
+            #endif
             return
         }
 

--- a/Sources/Harbor/Utils/PKCS12.swift
+++ b/Sources/Harbor/Utils/PKCS12.swift
@@ -19,7 +19,7 @@ final class PKCS12 {
     var identity: SecIdentity?
     var loggingEnabled: Bool
 
-    init(p12Data: Data, password: String, loggingEnabled: Bool = true) {
+    init(p12Data: Data, password: String, loggingEnabled: Bool = false) {
         self.loggingEnabled = loggingEnabled
         let importPasswordOption: NSDictionary = [kSecImportExportPassphrase as NSString: password]
 

--- a/Tests/HarborTests/HarborDebugTests.swift
+++ b/Tests/HarborTests/HarborDebugTests.swift
@@ -224,7 +224,7 @@ final class HarborDebugTests: XCTestCase {
         
         // This test verifies that the method doesn't crash when called
         // The actual logging is handled by LogBird and would require more complex mocking
-        await XCTAssertNoThrowAsync(await request.printRequest(urlRequest: urlRequest))
+        await XCTAssertNoThrowAsync(await request.logRequest(urlRequest: urlRequest))
     }
     
     func testPrintRequestWithNoneDebugType() async {
@@ -232,7 +232,7 @@ final class HarborDebugTests: XCTestCase {
         let urlRequest = URLRequest(url: URL(string: "https://api.example.com/test")!)
         
         // Should not crash even with .none debug type
-        await XCTAssertNoThrowAsync(await request.printRequest(urlRequest: urlRequest))
+        await XCTAssertNoThrowAsync(await request.logRequest(urlRequest: urlRequest))
     }
     
     func testPrintResponseWithResponseDebugType() async {
@@ -243,14 +243,14 @@ final class HarborDebugTests: XCTestCase {
                                       headerFields: nil)!
         let data = "test response".data(using: .utf8)!
         
-        await XCTAssertNoThrowAsync(await request.printResponse(httpResponse: response, data: data, duration: 123.45))
+        await XCTAssertNoThrowAsync(await request.logResponse(httpResponse: response, data: data, duration: 123.45))
     }
     
     func testPrintErrorResponseWithError() async {
         let request = TestDebugRequest(debugType: .requestAndResponse)
         let error = HRequestError.noConnectionError
         
-        await XCTAssertNoThrowAsync(await request.printErrorResponse(error: error))
+        await XCTAssertNoThrowAsync(await request.logErrorResponse(error: error))
     }
 }
 

--- a/Tests/HarborTests/HarborDebugTests.swift
+++ b/Tests/HarborTests/HarborDebugTests.swift
@@ -224,7 +224,7 @@ final class HarborDebugTests: XCTestCase {
         
         // This test verifies that the method doesn't crash when called
         // The actual logging is handled by LogBird and would require more complex mocking
-        await XCTAssertNoThrowAsync(await request.printRequest(urlRequest: urlRequest))
+        await XCTAssertNoThrowAsync(await request.logRequest(urlRequest: urlRequest))
     }
     
     func testPrintRequestWithNoneDebugType() async {
@@ -232,7 +232,7 @@ final class HarborDebugTests: XCTestCase {
         let urlRequest = URLRequest(url: URL(string: "https://api.example.com/test")!)
         
         // Should not crash even with .none debug type
-        await XCTAssertNoThrowAsync(await request.printRequest(urlRequest: urlRequest))
+        await XCTAssertNoThrowAsync(await request.logRequest(urlRequest: urlRequest))
     }
     
     func testPrintResponseWithResponseDebugType() async {
@@ -243,14 +243,14 @@ final class HarborDebugTests: XCTestCase {
                                       headerFields: nil)!
         let data = "test response".data(using: .utf8)!
         
-        await XCTAssertNoThrowAsync(await request.printResponse(httpResponse: response, data: data, duration: 123.45))
+        await XCTAssertNoThrowAsync(await request.logResponse(httpResponse: response, data: data, duration: 123.45))
     }
     
     func testPrintErrorResponseWithError() async {
         let request = TestDebugRequest(debugType: .requestAndResponse)
         let error = HRequestError.noConnectionError
         
-        await XCTAssertNoThrowAsync(await request.printErrorResponse(error: error))
+        await XCTAssertNoThrowAsync(await request.logErrorResponse(error: error))
     }
 }
 
@@ -266,4 +266,3 @@ private struct TestDebugRequest: HGetRequestProtocol, HDebugRequestProtocol {
         self.debugType = debugType
     }
 }
-


### PR DESCRIPTION
## Summary
This PR enhances the security and control of logging in Release builds to prevent sensitive data leakage.

Key changes:
- Renamed debug logging methods to `logRequest`, `logResponse`, and `logErrorResponse` for clarity.
- Added `isLoggingEnabled` flag to `HConfig` to allow runtime control of logging.
- Wrapped sensitive logging (e.g., request/response bodies, PKCS12 errors) in `#if DEBUG` blocks and checked `isLoggingEnabled`.
- Updated `PKCS12` initialization to accept a `loggingEnabled` parameter.
- Exposed `Harbor.setLoggingEnabled(_:)` to allow consumers to toggle logging.

## Test Plan
- [ ] Verify that logs are printed in DEBUG builds when `isLoggingEnabled` is true.
- [ ] Verify that logs are NOT printed in DEBUG builds when `isLoggingEnabled` is false.
- [ ] Verify that logs are NOT printed in RELEASE builds regardless of `isLoggingEnabled` (due to `#if DEBUG`).
- [ ] Verify that `PKCS12` related errors are suppressed in Release builds.
- [ ] Run unit tests to ensure no regressions in request flow.
