### PR TITLE
Update error cases for consistency and add mapURLError method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - `Harbor.setSSlPinningSHA256(_:)` renamed to `Harbor.setSSlPinningKeys(_:)` - now accepts array for key rotation
 - Network monitoring migrated from SystemConfiguration to NWPathMonitor
 - SHA256 migrated from CommonCrypto to CryptoKit
+- Renamed error cases for consistency: `apiError` → `api`, `codableError` → `codable`, `noConnectionError` → `noConnection`, `malformedRequestError` → `malformedRequest`, `timeoutError` → `timeout`, `sslError` → `certificate`
+- Added `HRequestError.mapURLError(_:)` static method for URL error mapping
 
 ### Fixed
 - clearCache now uses proper URLRequest for URLCache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### ⚠️ Breaking Changes
 - SSL pinning: `setSSlPinningSHA256(String?)` → `setSSlPinningKeys([String]?)`
+- Error cases renamed: `apiError` → `api`, `codableError` → `codable`, `noConnectionError` → `noConnection`, `malformedRequestError` → `malformedRequest`, `timeoutError` → `timeout`, `sslError` → `certificate`
 
 ## 3.0.0 - Response cases, Logging (2023-12-25)
 

--- a/Sources/Harbor/Request/HRequestError.swift
+++ b/Sources/Harbor/Request/HRequestError.swift
@@ -11,7 +11,7 @@ import Network
 /// Errors that can occur during network requests.
 public enum HRequestError: Error, Sendable {
     /// API returned an error with status code and response data.
-    case apiError(statusCode: Int, data: Data)
+    case api(statusCode: Int, data: Data)
     /// Invalid HTTP response received.
     case invalidHttpResponse
     /// The request is invalid or malformed.
@@ -21,28 +21,49 @@ public enum HRequestError: Error, Sendable {
     /// Authentication is required for this request.
     case authNeeded
     /// Error occurred while encoding/decoding the model.
-    case codableError(modelName: String, error: Error)
+    case codable(modelName: String, error: Error)
     /// No internet connection available.
-    case noConnectionError
+    case noConnection
     /// The request is malformed and cannot be processed.
-    case malformedRequestError
+    case malformedRequest
     /// Request timed out.
-    case timeoutError
+    case timeout
     /// Cannot find the specified host or connection failed.
     case cannotFindHost
     /// Request was cancelled.
     case cancelled
     /// SSL/TLS certificate validation failed.
-    case sslError
+    case certificate
     /// No cached data found for cache-only request.
     case noCachedDataFound
 }
 
 // MARK: - Error Description
 extension HRequestError: LocalizedError {
+    static func mapURLError(_ error: URLError) -> HRequestError {
+        switch error.code {
+        case .cancelled:
+            return .cancelled
+        case .badURL:
+            return .malformedRequest
+        case .cannotConnectToHost:
+            return .cannotFindHost
+        case .serverCertificateUntrusted:
+            return .certificate
+        case .timedOut:
+            return .timeout
+        case .notConnectedToInternet, .networkConnectionLost:
+            return .noConnection
+        case .cannotFindHost:
+            return .cannotFindHost
+        default:
+            return .invalidHttpResponse
+        }
+    }
+
     public var errorDescription: String? {
         switch self {
-        case .apiError(let statusCode, _):
+        case .api(let statusCode, _):
             return "API error with status code: \(statusCode)"
         case .invalidHttpResponse:
             return "Invalid HTTP response received"
@@ -52,19 +73,19 @@ extension HRequestError: LocalizedError {
             return "Authentication provider is required"
         case .authNeeded:
             return "Authentication is required"
-        case .codableError(let modelName, let error):
+        case .codable(let modelName, let error):
             return "Failed to encode/decode \(modelName): \(error.localizedDescription)"
-        case .noConnectionError:
+        case .noConnection:
             return "No internet connection available"
-        case .malformedRequestError:
+        case .malformedRequest:
             return "Malformed request"
-        case .timeoutError:
+        case .timeout:
             return "Request timed out"
         case .cannotFindHost:
             return "Cannot find host or connection failed"
         case .cancelled:
             return "Request was cancelled"
-        case .sslError:
+        case .certificate:
             return "SSL/TLS certificate validation failed"
         case .noCachedDataFound:
             return "No cached data found"

--- a/Sources/Harbor/Request/HRequestManager.swift
+++ b/Sources/Harbor/Request/HRequestManager.swift
@@ -37,7 +37,7 @@ extension HRequestManager {
         }
 
         if !self.isConnectedToNetwork() {
-            let hError: HRequestError = .noConnectionError
+            let hError: HRequestError = .noConnection
             logError(hError, request: request)
             return .error(hError)
         }
@@ -54,7 +54,7 @@ extension HRequestManager {
 
     private static func requestHandler<Model: HModel>(model: Model.Type, request: any HRequestWithResultProtocol) async -> HResponseWithResult<Model> {
         guard let urlRequest = HURLBuilder.buildUrlRequest(request: request) else {
-            let hError: HRequestError = .malformedRequestError
+            let hError: HRequestError = .malformedRequest
             logError(hError, request: request)
             return .error(hError)
         }
@@ -94,25 +94,7 @@ extension HRequestManager {
                                          data: data,
                                          httpResponse: httpResponse)
         } catch let error as URLError {
-            let hError: HRequestError
-            switch error.code {
-            case .cancelled:
-                hError = .cancelled
-            case .badURL:
-                hError = .malformedRequestError
-            case .cannotConnectToHost, .serverCertificateUntrusted:
-                hError = .cannotFindHost
-            case .timedOut:
-                hError = .timeoutError
-            case .notConnectedToInternet, .networkConnectionLost:
-                hError = .noConnectionError
-            case .cannotFindHost:
-                hError = .cannotFindHost
-            default:
-                hError = .invalidHttpResponse
-            }
-            logError(hError, request: request)
-            return .error(hError)
+            return .error(HRequestError.mapURLError(error))
         } catch {
             let hError: HRequestError = .invalidRequest
             logError(hError, request: request)
@@ -132,7 +114,7 @@ extension HRequestManager {
 
                 return .success(parsedResponse)
             } catch let parseError {
-                let hError: HRequestError = .codableError(modelName: "\(model.self)", error: parseError)
+                let hError: HRequestError = .codable(modelName: "\(model.self)", error: parseError)
                 logError(hError, request: request)
                 return .error(hError)
             }
@@ -144,7 +126,7 @@ extension HRequestManager {
                let cachedModel = cachedAny as? Model {
                 return .success(cachedModel)
             } else {
-                let hError: HRequestError = .apiError(statusCode: statusCode, data: data)
+                let hError: HRequestError = .api(statusCode: statusCode, data: data)
                 logError(hError, request: request)
                 return .error(hError)
             }
@@ -163,7 +145,7 @@ extension HRequestManager {
                 mutableRequest.retries = retries - 1
                 return await self.request(model: model, request: mutableRequest)
             } else {
-                let hError: HRequestError = .apiError(statusCode: statusCode, data: data)
+                let hError: HRequestError = .api(statusCode: statusCode, data: data)
                 logError(hError, request: request)
                 return .error(hError)
             }
@@ -190,7 +172,7 @@ extension HRequestManager {
         }
 
         if !self.isConnectedToNetwork() {
-            let hError: HRequestError = .noConnectionError
+            let hError: HRequestError = .noConnection
             logError(hError, request: request)
             return .error(hError)
         }
@@ -207,7 +189,7 @@ extension HRequestManager {
 
     private static func requestHandler<P: HRequestWithEmptyResponseProtocol>(request: P) async -> HResponse {
         guard let urlRequest = HURLBuilder.buildUrlRequest(request: request) else {
-            let hError: HRequestError = .malformedRequestError
+            let hError: HRequestError = .malformedRequest
             logError(hError, request: request)
             return .error(hError)
         }
@@ -243,25 +225,7 @@ extension HRequestManager {
 
             return await processResponse(request: request, statusCode: httpResponse.statusCode, data: data)
         } catch let error as URLError {
-            let hError: HRequestError
-            switch error.code {
-            case .cancelled:
-                hError = .cancelled
-            case .badURL:
-                hError = .malformedRequestError
-            case .cannotConnectToHost, .serverCertificateUntrusted:
-                hError = .cannotFindHost
-            case .timedOut:
-                hError = .timeoutError
-            case .notConnectedToInternet, .networkConnectionLost:
-                hError = .noConnectionError
-            case .cannotFindHost:
-                hError = .cannotFindHost
-            default:
-                hError = .invalidHttpResponse
-            }
-            logError(hError, request: request)
-            return .error(hError)
+            return .error(HRequestError.mapURLError(error))
         } catch {
             let hError: HRequestError = .invalidRequest
             logError(hError, request: request)
@@ -288,7 +252,7 @@ extension HRequestManager {
                 mutableRequest.retries = retries - 1
                 return await self.request(request: mutableRequest)
             } else {
-                let hError: HRequestError = .apiError(statusCode: statusCode, data: data)
+                let hError: HRequestError = .api(statusCode: statusCode, data: data)
                 logError(hError, request: request)
                 return .error(hError)
             }

--- a/Sources/HarborJRPC/Request/HJRPCRequestError.swift
+++ b/Sources/HarborJRPC/Request/HJRPCRequestError.swift
@@ -11,7 +11,7 @@ import Harbor
 /// Errors that can occur during JSON-RPC requests.
 public enum HJRPCRequestError: Error, Sendable {
     /// API returned an error with status code and response data.
-    case apiError(statusCode: Int, data: Data)
+    case api(statusCode: Int, data: Data)
     /// JSON-RPC specific error returned by the server.
     case jrpcError(error: HJRPCError)
     /// Base URL is required but not set.
@@ -25,17 +25,17 @@ public enum HJRPCRequestError: Error, Sendable {
     /// Authentication is required for this request.
     case authNeeded
     /// Error occurred while encoding/decoding the model.
-    case codableError(modelName: String, error: Error)
+    case codable(modelName: String, error: Error)
     /// No internet connection available.
-    case noConnectionError
+    case noConnection
     /// The request is malformed and cannot be processed.
-    case malformedRequestError
+    case malformedRequest
     /// Request timed out.
-    case timeoutError
+    case timeout
     /// Cannot find the specified host.
     case cannotFindHost
     /// SSL/TLS certificate validation failed.
-    case sslError
+    case certificate
     /// Request was cancelled.
     case cancelled
 }
@@ -43,8 +43,8 @@ public enum HJRPCRequestError: Error, Sendable {
 extension HJRPCRequestError {
     static func getError(hRequestError: HRequestError) -> HJRPCRequestError {
         switch hRequestError {
-        case .apiError(let statusCode, let data):
-            return .apiError(statusCode: statusCode, data: data)
+        case .api(let statusCode, let data):
+            return .api(statusCode: statusCode, data: data)
         case .invalidHttpResponse:
             return .invalidHttpResponse
         case .invalidRequest:
@@ -53,20 +53,20 @@ extension HJRPCRequestError {
             return .authProviderNeeded
         case .authNeeded:
             return .authNeeded
-        case .codableError(let modelName, let error):
-            return .codableError(modelName: modelName, error: error)
-        case .noConnectionError:
-            return .noConnectionError
-        case .malformedRequestError:
-            return .malformedRequestError
-        case .timeoutError:
-            return .timeoutError
+        case .codable(let modelName, let error):
+            return .codable(modelName: modelName, error: error)
+        case .noConnection:
+            return .noConnection
+        case .malformedRequest:
+            return .malformedRequest
+        case .timeout:
+            return .timeout
         case .cannotFindHost:
             return .cannotFindHost
         case .cancelled:
             return .cancelled
-        case .sslError:
-            return .sslError
+        case .certificate:
+            return .certificate
         case .noCachedDataFound:
             return .invalidRequest
         }

--- a/Tests/HarborTests/HarborDebugTests.swift
+++ b/Tests/HarborTests/HarborDebugTests.swift
@@ -248,7 +248,7 @@ final class HarborDebugTests: XCTestCase {
     
     func testPrintErrorResponseWithError() async {
         let request = TestDebugRequest(debugType: .requestAndResponse)
-        let error = HRequestError.noConnectionError
+        let error = HRequestError.noConnection
         
         await XCTAssertNoThrowAsync(await request.logErrorResponse(error: error))
     }

--- a/Tests/HarborTests/HarborManagerTests.swift
+++ b/Tests/HarborTests/HarborManagerTests.swift
@@ -87,7 +87,7 @@ final class HarborManagerTests: XCTestCase {
         case .error(let error):
             // Should be API error after retries exhausted
             switch error {
-            case .apiError(statusCode: let code, data: _):
+            case .api(statusCode: let code, data: _):
                 XCTAssertEqual(code, 500)
             default:
                 XCTFail("Expected API error but got: \(error)")

--- a/Tests/HarborTests/HarborMockTests.swift
+++ b/Tests/HarborTests/HarborMockTests.swift
@@ -79,7 +79,7 @@ final class HarborMockTests: XCTestCase {
         await Harbor.remove(mock: successMock)
 
         // Register a different mock to verify removal worked
-        let errorMock = await HMock(request: MockGetRequest<MockModel>.self, statusCode: 500, error: .noConnectionError)
+        let errorMock = await HMock(request: MockGetRequest<MockModel>.self, statusCode: 500, error: .noConnection)
         await Harbor.register(mock: errorMock)
 
         // Request should now get the error mock (proving first mock was removed)
@@ -91,11 +91,11 @@ final class HarborMockTests: XCTestCase {
             XCTFail("Expected error from new mock after removal")
         case .error(let error):
             switch error {
-            case .noConnectionError:
+            case .noConnection:
                 // This proves the first mock was removed and second mock is active
                 XCTAssertTrue(true)
             default:
-                XCTFail("Expected noConnectionError but got: \(error)")
+                XCTFail("Expected noConnection but got: \(error)")
             }
         }
     }

--- a/Tests/HarborTests/HarborRequestManagerAuthTests.swift
+++ b/Tests/HarborTests/HarborRequestManagerAuthTests.swift
@@ -23,17 +23,17 @@ extension HRequestError: Equatable {
         switch (lhs, rhs) {
         case (.authProviderNeeded, .authProviderNeeded):
             return true
-        case (.noConnectionError, .noConnectionError):
+        case (.noConnection, .noConnection):
             return true
-        case (.malformedRequestError, .malformedRequestError):
+        case (.malformedRequest, .malformedRequest):
             return true
-        case (.timeoutError, .timeoutError):
+        case (.timeout, .timeout):
             return true
         case (.invalidHttpResponse, .invalidHttpResponse):
             return true
-        case (.codableError(let lhsModel, _), .codableError(let rhsModel, _)):
+        case (.codable(let lhsModel, _), .codable(let rhsModel, _)):
             return lhsModel == rhsModel
-        case (.apiError(let lhsStatusCode, _), .apiError(let rhsStatusCode, _)):
+        case (.api(let lhsStatusCode, _), .api(let rhsStatusCode, _)):
             return lhsStatusCode == rhsStatusCode
         default:
             return false

--- a/Tests/HarborTests/HarborSecurityTests.swift
+++ b/Tests/HarborTests/HarborSecurityTests.swift
@@ -163,7 +163,7 @@ final class HarborSecurityTests: XCTestCase {
         Harbor.setSSlPinningKeys([testSHA256])
         
         // Mock a SSL-related failure (using existing error types)
-        let mock = HMock(request: SecureGetRequest.self, statusCode: 500, error: .noConnectionError)
+        let mock = HMock(request: SecureGetRequest.self, statusCode: 500, error: .noConnection)
         Harbor.register(mock: mock)
         
         // When
@@ -176,7 +176,7 @@ final class HarborSecurityTests: XCTestCase {
             XCTFail("Expected SSL-related failure")
         case .error(let error):
             switch error {
-            case .noConnectionError:
+            case .noConnection:
                 XCTAssertTrue(true) // Expected connection error (SSL-related)
             default:
                 XCTFail("Expected connection error but got: \(error)")
@@ -205,7 +205,7 @@ final class HarborSecurityTests: XCTestCase {
             XCTFail("Expected certificate-related error")
         case .error(let error):
             switch error {
-            case .apiError(statusCode: let code, data: _):
+            case .api(statusCode: let code, data: _):
                 XCTAssertEqual(code, 403) // Expected 403 Forbidden (certificate issue)
             default:
                 XCTFail("Expected API error with 403 status but got: \(error)")

--- a/Tests/HarborTests/HarborTests.swift
+++ b/Tests/HarborTests/HarborTests.swift
@@ -181,7 +181,7 @@ final class HarborTests: XCTestCase {
     
     func testNetworkErrorHandling() async throws {
         // Given
-        let mock = await HMock(request: GetUserRequest.self, statusCode: 500, error: .noConnectionError)
+        let mock = await HMock(request: GetUserRequest.self, statusCode: 500, error: .noConnection)
         await Harbor.register(mock: mock)
         
         // When
@@ -194,10 +194,10 @@ final class HarborTests: XCTestCase {
             XCTFail("Expected network error")
         case .error(let error):
             switch error {
-            case .noConnectionError:
+            case .noConnection:
                 XCTAssertTrue(true) // Expected network error
             default:
-                XCTFail("Expected noConnectionError but got: \(error)")
+                XCTFail("Expected noConnection but got: \(error)")
             }
         }
     }
@@ -236,7 +236,7 @@ final class HarborTests: XCTestCase {
         case .error(let error):
             // Should be a codable/parsing error
             switch error {
-            case .codableError:
+            case .codable:
                 XCTAssertTrue(true)
             default:
                 XCTFail("Expected codable error but got: \(error)")
@@ -272,7 +272,7 @@ final class HarborTests: XCTestCase {
     
     func testRequestTimeout() async throws {
         // Given
-        let mock = await HMock(request: TimeoutRequest.self, statusCode: 408, error: .timeoutError)
+        let mock = await HMock(request: TimeoutRequest.self, statusCode: 408, error: .timeout)
         await Harbor.register(mock: mock)
         
         // When
@@ -285,7 +285,7 @@ final class HarborTests: XCTestCase {
             XCTFail("Expected timeout error")
         case .error(let error):
             switch error {
-            case .timeoutError:
+            case .timeout:
                 XCTAssertTrue(true) // Expected timeout error
             default:
                 XCTFail("Expected timeout error but got: \(error)")
@@ -295,7 +295,7 @@ final class HarborTests: XCTestCase {
     
     func testConnectionFailure() async throws {
         // Given
-        let mock = await HMock(request: ConnectionFailureRequest.self, statusCode: 0, error: .noConnectionError)
+        let mock = await HMock(request: ConnectionFailureRequest.self, statusCode: 0, error: .noConnection)
         await Harbor.register(mock: mock)
         
         // When
@@ -308,7 +308,7 @@ final class HarborTests: XCTestCase {
             XCTFail("Expected connection error")
         case .error(let error):
             switch error {
-            case .noConnectionError:
+            case .noConnection:
                 XCTAssertTrue(true) // Expected connection error
             default:
                 XCTFail("Expected connection error but got: \(error)")
@@ -341,7 +341,7 @@ final class HarborTests: XCTestCase {
     
     func testMalformedRequest() async throws {
         // Given
-        let mock = await HMock(request: MalformedRequest.self, statusCode: 400, error: .malformedRequestError)
+        let mock = await HMock(request: MalformedRequest.self, statusCode: 400, error: .malformedRequest)
         await Harbor.register(mock: mock)
         
         // When
@@ -354,7 +354,7 @@ final class HarborTests: XCTestCase {
             XCTFail("Expected malformed request error")
         case .error(let error):
             switch error {
-            case .malformedRequestError:
+            case .malformedRequest:
                 XCTAssertTrue(true) // Expected malformed request error
             default:
                 XCTFail("Expected malformed request error but got: \(error)")
@@ -699,7 +699,7 @@ private struct CancellableRequest: HGetRequestProtocol {
 private extension HRequestError {
     var isApiError: Bool {
         switch self {
-        case .apiError:
+        case .api:
             return true
         default:
             return false

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -196,7 +196,7 @@ case .error(let error):
     switch error {
     case .authNeeded:
         // Handle authentication
-    case .noConnectionError:
+    case .noConnection:
         // Handle connection error
     default:
         print("Error: \(error)")

--- a/skill/examples/advanced.md
+++ b/skill/examples/advanced.md
@@ -465,7 +465,7 @@ func fetchDataWithErrorRecovery<T: HGetRequestProtocol>(
                 }
                 return nil
                 
-            case .noConnectionError:
+            case .noConnection:
                 // Wait and retry
                 if attempt < maxRetries {
                     let delay = UInt64(pow(2.0, Double(attempt)) * 1_000_000_000) // Exponential backoff

--- a/skill/examples/basic.md
+++ b/skill/examples/basic.md
@@ -307,7 +307,7 @@ case .error(let error):
         // Redirect to login
         showLoginScreen()
         
-    case .noConnectionError:
+    case .noConnection:
         // Show offline message
         showOfflineAlert()
         
@@ -601,7 +601,7 @@ func fetchUserWithRetry(userId: String, maxAttempts: Int = 3) async -> User? {
                 return nil
             }
             
-            if case .noConnectionError = error {
+            if case .noConnection = error {
                 // Wait before retry
                 try? await Task.sleep(nanoseconds: UInt64(attempt) * 1_000_000_000)
             } else {

--- a/skill/protocols.md
+++ b/skill/protocols.md
@@ -530,7 +530,7 @@ case .error(let error):
 ```swift
 enum HRequestError: Error {
     case authNeeded
-    case noConnectionError
+    case noConnection
     case invalidURL
     case invalidResponse
     case decodingError(Error)
@@ -551,7 +551,7 @@ case .error(let error):
     switch error {
     case .authNeeded:
         // Re-authenticate user
-    case .noConnectionError:
+    case .noConnection:
         // Show offline message
     case .decodingError(let decodingError):
         // Log decoding issue

--- a/skill/testing.md
+++ b/skill/testing.md
@@ -103,7 +103,7 @@ await Harbor.register(mock: mock)
 // Simulate network error
 let mock = await HMock(
     request: GetUserRequest.self,
-    error: .noConnectionError
+    error: .noConnection
 )
 
 await Harbor.register(mock: mock)
@@ -362,7 +362,7 @@ func testNetworkError() async throws {
     // Given
     let mock = await HMock(
         request: GetUserRequest.self,
-        error: .noConnectionError
+        error: .noConnection
     )
     await Harbor.register(mock: mock)
     
@@ -374,7 +374,7 @@ func testNetworkError() async throws {
     case .success:
         XCTFail("Expected error but got success")
     case .error(let error):
-        XCTAssertEqual(error, .noConnectionError)
+        XCTAssertEqual(error, .noConnection)
     }
 }
 ```


### PR DESCRIPTION
## Summary
- Renamed error cases for consistency: `apiError` → `api`, `codableError` → `codable`, `noConnectionError` → `noConnection`, `malformedRequestError` → `malformedRequest`, `timeoutError` → `timeout`, `sslError` → `certificate`
- Added `HRequestError.mapURLError(_:)` static method for URL error mapping