### PR TITLE
fix: false .noConnection on first request in Release + Example app feedback

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -22,13 +22,13 @@ jobs:
       run: swift test -v --enable-code-coverage
 
     # 2. Run Example App Tests (Integration via xcodebuild)
-    # Using iPhone 16e on macos-26
+    # Using iPhone 17 on macos-26 (available on the latest simulator runtime)
     - name: Run Example App Tests
       run: |
         xcodebuild test \
           -project Example/HarborExample.xcodeproj \
           -scheme HarborExample \
-          -destination 'platform=iOS Simulator,name=iPhone 16e' \
+          -destination 'platform=iOS Simulator,name=iPhone 17' \
           -resultBundlePath TestResults \
           CODE_SIGN_IDENTITY="" \
           CODE_SIGNING_REQUIRED=NO \

--- a/Example/HarborExample/RequestsView.swift
+++ b/Example/HarborExample/RequestsView.swift
@@ -13,6 +13,7 @@ import LogBird
 struct RequestsView: View {
     @State private var results: [String] = []
     @State private var isLoading: Bool = false
+    @State private var isSettingsPresented: Bool = false
 
     // Static logger using LogBird
     private static let logger = LogBird(subsystem: "com.harbor.example", category: "RequestsView")
@@ -56,173 +57,154 @@ struct RequestsView: View {
 
     var body: some View {
         NavigationView {
-            ScrollView {
-                VStack(spacing: 20) {
-                    // MARK: - Basic Requests Section
-                    Section {
-                        SectionHeader(title: "Basic GET Requests")
-
-                        ExampleButton(title: "GET - Simple Request", icon: "arrow.down.circle", action: { performBasicGet() })
-                        
-
-                        ExampleButton(title: "GET - With Path Parameter", icon: "arrow.right.circle", action: { performGetWithPathParameter() })
-                        
-
-                        ExampleButton(title: "GET - With Query Params", icon: "magnifyingglass", action: { performGetWithQueryParams() })
-                        
-                    }
-
-                    // MARK: - POST Requests
-                    Section {
-                        SectionHeader(title: "POST Requests")
-
-                        ExampleButton(title: "POST - Create Resource", icon: "plus.circle", action: { performPostRequest() })
-
-                        ExampleButton(title: "POST - Multipart Upload", icon: "paperclip", action: { performMultipartPost() })
-                    }
-
-                    // MARK: - PUT & PATCH
-                    Section {
-                        SectionHeader(title: "PUT & PATCH")
-
-                        ExampleButton(title: "PUT - Full Update", icon: "arrow.triangle.2.circlepath", action: { performPutRequest() })
-
-                        ExampleButton(title: "PATCH - Partial Update", icon: "pencil", action: { performPatchRequest() })
-                    }
-
-                    // MARK: - DELETE
-                    Section {
-                        SectionHeader(title: "DELETE")
-
-                        ExampleButton(title: "DELETE - Remove Resource", icon: "trash", action: { performDeleteRequest() })
-                    }
-
-                    // MARK: - Caching
-                    Section {
-                        SectionHeader(title: "Caching")
-
-                        ExampleButton(title: "GET - With Custom Cache", icon: "externaldrive", action: { performCachedRequest() })
-
-                        ExampleButton(title: "GET - With URLCache (ETags)", icon: "network", action: { performURLCacheRequest() })
-
-                        ExampleButton(title: "GET - Cache Only", icon: "internaldrive", action: { performCacheOnlyRequest() })
-
-                        ExampleButton(title: "GET - Remote Only", icon: "antenna.radiowaves.left.and.right", action: { performRemoteOnlyRequest() })
-
-                        ExampleButton(title: "Clear All Cache", icon: "xmark.circle", isDestructive: true, action: { clearAllCache() })
-                    }
-
-                    // MARK: - Streaming
-                    Section {
-                        SectionHeader(title: "Streaming")
-
-                        ExampleButton(title: "Stream - Cache + Remote", icon: "arrow.triangle.2.circlepath.circle", action: { performStreamRequest() })
-                    }
-
-                    // MARK: - Pagination
-                    Section {
-                        SectionHeader(title: "Pagination")
-
-                        ExampleButton(title: "GET - Paginated", icon: "number", action: { performPaginatedRequest() })
-                    }
-
-                    // MARK: - Authentication
-                    Section {
-                        SectionHeader(title: "Authentication")
-
-                        ExampleButton(title: "GET - With Auth", icon: "lock.shield", action: { performAuthenticatedRequest() })
-
-                        ExampleButton(title: "GET - Auth with Token Refresh", icon: "lock.rotation", action: { performAuthWithRefresh() })
-                    }
-
-                    // MARK: - Headers
-                    Section {
-                        SectionHeader(title: "Custom Headers")
-
-                        ExampleButton(title: "GET - Custom Headers", icon: "header", action: { performRequestWithHeaders() })
-                    }
-
-                    // MARK: - Retry
-                    Section {
-                        SectionHeader(title: "Retry Logic")
-
-                        ExampleButton(title: "GET - With Retry (3x)", icon: "arrow.clockwise.circle", action: { performRequestWithRetry() })
-                    }
-
-                    // MARK: - Error Handling
-                    Section {
-                        SectionHeader(title: "Error Handling")
-
-                        ExampleButton(title: "Handle Errors", icon: "exclamationmark.triangle", action: { performErrorHandling() })
-                    }
-
-                    // MARK: - JSON-RPC
-                    Section {
-                        SectionHeader(title: "JSON-RPC (Ethereum)")
-
-                        ExampleButton(title: "JRPC - Block Number", icon: "bitcoinsign.circle", action: { performJRPCRequest() })
-
-                        ExampleButton(title: "JRPC - Get Balance", icon: "dollarsign.circle", action: { performJRPCBalanceRequest() })
-                    }
-
-                    // MARK: - mTLS
-                    Section {
-                        SectionHeader(title: "Security (mTLS)")
-
-                        ExampleButton(title: "GET - With mTLS", icon: "lock.icloud", action: { performMTLSRequest() })
-
-                        ExampleButton(title: "Configure SSL Pinning", icon: "checkmark.shield", action: { configureSSLPinning() })
-                    }
-
-                    // MARK: - Debug
-                    Section {
-                        SectionHeader(title: "Debug Mode")
-
-                        ExampleButton(title: "GET - Debug Mode", icon: "antenna.radiowaves.left.and.right", action: { performDebugRequest() })
-                    }
-
-                    // MARK: - Results Display
-                    if !results.isEmpty {
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(spacing: 20) {
+                        // MARK: - Basic Requests Section
                         Section {
-                            SectionHeader(title: "Results")
+                            SectionHeader(title: "Basic GET Requests")
 
-                            VStack(alignment: .leading, spacing: 8) {
-                                ForEach(Array(results.enumerated()), id: \.offset) { index, result in
-                                    HStack(alignment: .top) {
-                                        Text("\(index + 1).")
-                                            .font(.caption)
-                                            .foregroundColor(.secondary)
-                                        Text(result)
-                                            .font(.caption)
-                                            .multilineTextAlignment(.leading)
-                                    }
-                                }
-                            }
-                            .padding()
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(Color.gray.opacity(0.1))
-                            .cornerRadius(8)
+                            ExampleButton(title: "GET - Simple Request", icon: "arrow.down.circle", action: { performBasicGet() })
+                            
 
-                            Button("Clear Results") {
-                                results.removeAll()
-                            }
-                            .buttonStyle(.bordered)
+                            ExampleButton(title: "GET - With Path Parameter", icon: "arrow.right.circle", action: { performGetWithPathParameter() })
+                            
+
+                            ExampleButton(title: "GET - With Query Params", icon: "magnifyingglass", action: { performGetWithQueryParams() })
+                            
                         }
-                    }
 
-                    Spacer(minLength: 40)
+                        // MARK: - POST Requests
+                        Section {
+                            SectionHeader(title: "POST Requests")
+
+                            ExampleButton(title: "POST - Create Resource", icon: "plus.circle", action: { performPostRequest() })
+
+                            ExampleButton(title: "POST - Multipart Upload", icon: "paperclip", action: { performMultipartPost() })
+                        }
+
+                        // MARK: - PUT & PATCH
+                        Section {
+                            SectionHeader(title: "PUT & PATCH")
+
+                            ExampleButton(title: "PUT - Full Update", icon: "arrow.triangle.2.circlepath", action: { performPutRequest() })
+
+                            ExampleButton(title: "PATCH - Partial Update", icon: "pencil", action: { performPatchRequest() })
+                        }
+
+                        // MARK: - DELETE
+                        Section {
+                            SectionHeader(title: "DELETE")
+
+                            ExampleButton(title: "DELETE - Remove Resource", icon: "trash", action: { performDeleteRequest() })
+                        }
+
+                        // MARK: - Caching
+                        Section {
+                            SectionHeader(title: "Caching")
+
+                            ExampleButton(title: "GET - With Custom Cache", icon: "externaldrive", action: { performCachedRequest() })
+
+                            ExampleButton(title: "GET - With URLCache (ETags)", icon: "network", action: { performURLCacheRequest() })
+
+                            ExampleButton(title: "GET - Cache Only", icon: "internaldrive", action: { performCacheOnlyRequest() })
+
+                            ExampleButton(title: "GET - Remote Only", icon: "antenna.radiowaves.left.and.right", action: { performRemoteOnlyRequest() })
+
+                            ExampleButton(title: "Clear All Cache", icon: "xmark.circle", isDestructive: true, action: { clearAllCache() })
+                        }
+
+                        // MARK: - Streaming
+                        Section {
+                            SectionHeader(title: "Streaming")
+
+                            ExampleButton(title: "Stream - Cache + Remote", icon: "arrow.triangle.2.circlepath.circle", action: { performStreamRequest() })
+                        }
+
+                        // MARK: - Pagination
+                        Section {
+                            SectionHeader(title: "Pagination")
+
+                            ExampleButton(title: "GET - Paginated", icon: "number", action: { performPaginatedRequest() })
+                        }
+
+                        // MARK: - Authentication
+                        Section {
+                            SectionHeader(title: "Authentication")
+
+                            ExampleButton(title: "GET - With Auth", icon: "lock.shield", action: { performAuthenticatedRequest() })
+
+                            ExampleButton(title: "GET - Auth with Token Refresh", icon: "lock.rotation", action: { performAuthWithRefresh() })
+                        }
+
+                        // MARK: - Headers
+                        Section {
+                            SectionHeader(title: "Custom Headers")
+
+                            ExampleButton(title: "GET - Custom Headers", icon: "header", action: { performRequestWithHeaders() })
+                        }
+
+                        // MARK: - Retry
+                        Section {
+                            SectionHeader(title: "Retry Logic")
+
+                            ExampleButton(title: "GET - With Retry (3x)", icon: "arrow.clockwise.circle", action: { performRequestWithRetry() })
+                        }
+
+                        // MARK: - Error Handling
+                        Section {
+                            SectionHeader(title: "Error Handling")
+
+                            ExampleButton(title: "Handle Errors", icon: "exclamationmark.triangle", action: { performErrorHandling() })
+                        }
+
+                        // MARK: - JSON-RPC
+                        Section {
+                            SectionHeader(title: "JSON-RPC (Ethereum)")
+
+                            ExampleButton(title: "JRPC - Block Number", icon: "bitcoinsign.circle", action: { performJRPCRequest() })
+
+                            ExampleButton(title: "JRPC - Get Balance", icon: "dollarsign.circle", action: { performJRPCBalanceRequest() })
+                        }
+
+                        // MARK: - mTLS
+                        Section {
+                            SectionHeader(title: "Security (mTLS)")
+
+                            ExampleButton(title: "GET - With mTLS", icon: "lock.icloud", action: { performMTLSRequest() })
+
+                            ExampleButton(title: "Configure SSL Pinning", icon: "checkmark.shield", action: { configureSSLPinning() })
+                        }
+
+                        // MARK: - Debug
+                        Section {
+                            SectionHeader(title: "Debug Mode")
+
+                            ExampleButton(title: "GET - Debug Mode", icon: "antenna.radiowaves.left.and.right", action: { performDebugRequest() })
+                        }
+
+                        Spacer(minLength: 40)
+                    }
+                    .padding()
                 }
-                .padding()
+
+                // MARK: - Sticky Results Console
+                ResultsConsoleView(results: results) {
+                    results.removeAll()
+                }
             }
             .onAppear {
                 setupOnAppear()
             }
             .navigationTitle("Harbor Examples")
             .navigationBarItems(trailing:
-                Button(action: { showSettings() }) {
+                Button(action: { isSettingsPresented = true }) {
                     Image(systemName: "gear")
                 }
             )
+            .sheet(isPresented: $isSettingsPresented) {
+                SettingsView()
+            }
         }
         .overlay {
             if isLoading {
@@ -240,7 +222,7 @@ struct RequestsView: View {
     func performBasicGet() {
         Self.logger.log("performBasicGet called", level: .info)
         addResult("=== GET - Basic Request ===")
-        Task {
+        performWithLoading {
             let response = await GetUsersRequest().request()
             await MainActor.run {
                 switch response {
@@ -258,7 +240,7 @@ struct RequestsView: View {
 
     func performGetWithPathParameter() {
         addResult("=== GET - Path Parameter ===")
-        Task {
+        performWithLoading {
             let response = await GetUserRequest(userId: 1).request()
             await MainActor.run {
                 switch response {
@@ -274,7 +256,7 @@ struct RequestsView: View {
 
     func performGetWithQueryParams() {
         addResult("=== GET - Query Parameters ===")
-        Task {
+        performWithLoading {
             let response = await SearchUsersRequest(query: "Bret").request()
             await MainActor.run {
                 switch response {
@@ -291,7 +273,7 @@ struct RequestsView: View {
 
     func performPostRequest() {
         addResult("=== POST - Create Resource ===")
-        Task {
+        performWithLoading {
             let response = await CreatePostRequest(
                 title: "My New Post",
                 body: "This is the body of my post",
@@ -311,7 +293,7 @@ struct RequestsView: View {
 
     func performMultipartPost() {
         addResult("=== POST - Multipart ===")
-        Task {
+        performWithLoading {
             let imageData = "fake image data".data(using: .utf8)
             let response = await UploadPostRequest(
                 title: "Post with Image",
@@ -335,7 +317,7 @@ struct RequestsView: View {
 
     func performPutRequest() {
         addResult("=== PUT - Full Update ===")
-        Task {
+        performWithLoading {
             let response = await UpdatePostRequest(
                 postId: 1,
                 title: "Updated Title",
@@ -356,7 +338,7 @@ struct RequestsView: View {
 
     func performPatchRequest() {
         addResult("=== PATCH - Partial Update ===")
-        Task {
+        performWithLoading {
             let response = await PatchPostRequest(
                 postId: 1,
                 title: "Just the Title"
@@ -377,7 +359,7 @@ struct RequestsView: View {
 
     func performDeleteRequest() {
         addResult("=== DELETE - Remove Resource ===")
-        Task {
+        performWithLoading {
             let response = await DeletePostRequest(postId: 1).request()
 
             await MainActor.run {
@@ -395,7 +377,7 @@ struct RequestsView: View {
 
     func performCachedRequest() {
         addResult("=== GET - Custom Cache ===")
-        Task {
+        performWithLoading {
             let response = await GetUserProfileRequest(userId: 1).request()
 
             await MainActor.run {
@@ -411,7 +393,7 @@ struct RequestsView: View {
 
     func performURLCacheRequest() {
         addResult("=== GET - URLCache ===")
-        Task {
+        performWithLoading {
             let response = await GetPostsRequest().request()
 
             await MainActor.run {
@@ -427,7 +409,7 @@ struct RequestsView: View {
 
     func performCacheOnlyRequest() {
         addResult("=== GET - Cache Only ===")
-        Task {
+        performWithLoading {
             // First, populate cache
             _ = await GetUserRequest(userId: 1).request()
 
@@ -445,7 +427,7 @@ struct RequestsView: View {
 
     func performRemoteOnlyRequest() {
         addResult("=== GET - Remote Only ===")
-        Task {
+        performWithLoading {
             let response = await RemoteOnlyUsersRequest().request()
 
             await MainActor.run {
@@ -461,7 +443,7 @@ struct RequestsView: View {
 
     func clearAllCache() {
         addResult("=== Clearing Cache ===")
-        Task {
+        performWithLoading {
             await Harbor.clearAllCache()
             await MainActor.run {
                 addResult("All cache cleared!")
@@ -473,7 +455,7 @@ struct RequestsView: View {
 
     func performStreamRequest() {
         addResult("=== Stream - Cache + Remote ===")
-        Task {
+        performWithLoading {
             do {
                 // First populate cache
                 _ = await GetUserRequest(userId: 1).request()
@@ -497,7 +479,7 @@ struct RequestsView: View {
 
     func performPaginatedRequest() {
         addResult("=== GET - Paginated ===")
-        Task {
+        performWithLoading {
             let response = await GetPaginatedPostsRequest(page: 1, limit: 5).request()
 
             await MainActor.run {
@@ -515,7 +497,7 @@ struct RequestsView: View {
 
     func performAuthenticatedRequest() {
         addResult("=== GET - Authenticated ===")
-        Task {
+        performWithLoading {
             // Set auth provider
             authProvider.setToken("demo_token_123", expiresIn: 3600)
             await Harbor.setAuthProvider(authProvider)
@@ -535,7 +517,7 @@ struct RequestsView: View {
 
     func performAuthWithRefresh() {
         addResult("=== Auth with Token Refresh ===")
-        Task {
+        performWithLoading {
             // This would trigger authFailed() in the provider
             // which could refresh the token
             await Harbor.setAuthProvider(authProvider)
@@ -557,7 +539,7 @@ struct RequestsView: View {
 
     func performRequestWithHeaders() {
         addResult("=== GET - Custom Headers ===")
-        Task {
+        performWithLoading {
             let response = await GetDataWithHeadersRequest().request()
 
             await MainActor.run {
@@ -575,7 +557,7 @@ struct RequestsView: View {
 
     func performRequestWithRetry() {
         addResult("=== GET - With Retry ===")
-        Task {
+        performWithLoading {
             let response = await GetUnreliableDataRequest().request()
 
             await MainActor.run {
@@ -593,7 +575,7 @@ struct RequestsView: View {
 
     func performErrorHandling() {
         addResult("=== Error Handling Examples ===")
-        Task {
+        performWithLoading {
             let response = await ErrorProneRequest().request()
 
             await MainActor.run {
@@ -612,7 +594,7 @@ struct RequestsView: View {
 
     func performJRPCRequest() {
         addResult("=== JRPC - eth_blockNumber ===")
-        Task {
+        performWithLoading {
             let response = await JRPCRequest().request()
 
             await MainActor.run {
@@ -628,7 +610,7 @@ struct RequestsView: View {
 
     func performJRPCBalanceRequest() {
         addResult("=== JRPC - eth_getBalance ===")
-        Task {
+        performWithLoading {
             struct GetBalanceRequest: HJRPCRequestProtocol {
                 typealias Model = String
                 let method: String = "eth_getBalance"
@@ -657,7 +639,7 @@ struct RequestsView: View {
 
     func performMTLSRequest() {
         addResult("=== mTLS Request ===")
-        Task {
+        performWithLoading {
             let response = await MTLSRequest().request()
 
             await MainActor.run {
@@ -691,7 +673,7 @@ struct RequestsView: View {
 
     func performDebugRequest() {
         addResult("=== Debug Request ===")
-        Task {
+        performWithLoading {
             await Harbor.setLoggingEnabled(true)
             let response = await DebugGetUsersRequest().request()
 
@@ -706,20 +688,16 @@ struct RequestsView: View {
         }
     }
 
-    // MARK: - Settings
+    // MARK: - Helpers
 
-    func showSettings() {
-        addResult("=== Current Configuration ===")
+    /// Runs an async operation toggling the loading overlay.
+    private func performWithLoading(_ operation: @escaping () async -> Void) {
+        isLoading = true
         Task {
-            await MainActor.run {
-                addResult("Cache: URLCache (default)")
-                addResult("Logging: Enabled")
-                addResult("Default Headers: X-Client-Version, X-Client-Platform")
-            }
+            await operation()
+            await MainActor.run { isLoading = false }
         }
     }
-
-    // MARK: - Helpers
 
     func addResult(_ text: String) {
         results.append(text)
@@ -779,6 +757,88 @@ struct ExampleButton: View {
             RoundedRectangle(cornerRadius: 10)
                 .stroke(Color.accentColor, lineWidth: isDestructive ? 0 : 1)
         )
+    }
+}
+
+/// Simple read-only summary of the Harbor configuration used by the example.
+struct SettingsView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationView {
+            List {
+                Section(header: Text("Network")) {
+                    Label("Cache: URLCache (default)", systemImage: "externaldrive")
+                    Label("Timeout: 15s (default)", systemImage: "clock")
+                    Label("JRPC: ethereum.publicnode.com", systemImage: "link")
+                }
+
+                Section(header: Text("Default Headers")) {
+                    Label("X-Client-Version: 1.0.0", systemImage: "list.bullet.rectangle")
+                    Label("X-Client-Platform: iOS", systemImage: "list.bullet.rectangle")
+                }
+
+                Section(header: Text("Debug")) {
+                    Label("Logging: Enabled", systemImage: "antenna.radiowaves.left.and.right")
+                }
+            }
+            .navigationTitle("Settings")
+            .navigationBarItems(trailing: Button("Done") { dismiss() })
+        }
+    }
+}
+
+/// Console-style output panel pinned to the bottom of the screen.
+/// Shows example outputs and auto-scrolls to the newest entry.
+struct ResultsConsoleView: View {
+    let results: [String]
+    let onClear: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Divider()
+
+            HStack {
+                Text("Output")
+                    .font(.headline)
+                Spacer()
+                if !results.isEmpty {
+                    Button("Clear", action: onClear)
+                        .font(.caption)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 4) {
+                        if results.isEmpty {
+                            Text("Tap an example to see its output here")
+                                .foregroundColor(.secondary)
+                        } else {
+                            ForEach(Array(results.enumerated()), id: \.offset) { index, result in
+                                Text(result)
+                                    .id(index)
+                            }
+                        }
+                    }
+                    .font(.caption)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
+                }
+                .onChange(of: results.count) { _ in
+                    if let lastIndex = results.indices.last {
+                        withAnimation {
+                            proxy.scrollTo(lastIndex, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+            .frame(height: 160)
+            .background(Color.gray.opacity(0.1))
+        }
     }
 }
 

--- a/Sources/Harbor/Request/HRequestManager.swift
+++ b/Sources/Harbor/Request/HRequestManager.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Network
 
 /// Global actor to manage shared mutable state in a thread-safe way.
 /// This actor ensures that Harbor's internal state is accessed safely across concurrent contexts.
@@ -16,7 +15,11 @@ import Network
 }
 
 @HRequestManagerActor
-final class HRequestManager: Sendable {}
+final class HRequestManager: Sendable {
+    /// Connectivity monitor used as a pre-check before executing requests.
+    /// Owned here (typed as the protocol) so tests can substitute a fake.
+    static var connectivityMonitor: any HRequestManagerMonitorProtocol = HRequestManagerMonitor()
+}
 
 // MARK: - Request With Result
 extension HRequestManager {
@@ -36,7 +39,7 @@ extension HRequestManager {
             return await HRequestManager.processResponse(model: model, request: request, statusCode: mock.statusCode, data: data)
         }
 
-        if !self.isConnectedToNetwork() {
+        if !connectivityMonitor.isConnectedToNetwork() {
             let hError: HRequestError = .noConnection
             logError(hError, request: request)
             return .error(hError)
@@ -171,7 +174,7 @@ extension HRequestManager {
             return await HRequestManager.processResponse(request: request, statusCode: mock.statusCode, data: data)
         }
 
-        if !self.isConnectedToNetwork() {
+        if !connectivityMonitor.isConnectedToNetwork() {
             let hError: HRequestError = .noConnection
             logError(hError, request: request)
             return .error(hError)
@@ -339,31 +342,5 @@ private extension HRequestManager {
         }
 
         return false
-    }
-}
-
-// MARK: - Connectivity Functions
-private extension HRequestManager {
-    private static let monitor = NWPathMonitor()
-    private static let monitorQueue = DispatchQueue(label: "com.harbor.networkMonitor")
-    private static var isMonitorStarted = false
-
-    /// Enhanced network connectivity check using NWPathMonitor
-    static func isConnectedToNetwork() -> Bool {
-        if !isMonitorStarted {
-            monitor.start(queue: monitorQueue)
-            isMonitorStarted = true
-        }
-
-        if monitor.currentPath.status == .satisfied {
-            return true
-        }
-
-        // Fallback for debug/simulator environments
-        #if DEBUG || targetEnvironment(simulator)
-        return true
-        #else
-        return false
-        #endif
     }
 }

--- a/Sources/Harbor/Request/HRequestManagerMonitor.swift
+++ b/Sources/Harbor/Request/HRequestManagerMonitor.swift
@@ -1,0 +1,75 @@
+//
+//  HRequestManagerMonitor.swift
+//  Harbor
+//
+//  Network connectivity monitor used internally as a pre-check before executing requests.
+//
+
+import Foundation
+import Network
+
+/// Monitors network connectivity, used internally as a pre-check before executing requests.
+///
+/// The monitor starts lazily on the first connectivity check. Until it delivers its
+/// first path update the real status is unknown, so connectivity is assumed instead
+/// of failing requests spuriously. In DEBUG/simulator builds requests are always allowed.
+@HRequestManagerActor
+protocol HRequestManagerMonitorProtocol: Sendable {
+    /// Starts the network monitor if it is not already running.
+    func start()
+
+    /// Network connectivity check.
+    func isConnectedToNetwork() -> Bool
+}
+
+/// Default connectivity monitor backed by NWPathMonitor.
+@HRequestManagerActor
+final class HRequestManagerMonitor: HRequestManagerMonitorProtocol {
+    private let monitor = NWPathMonitor()
+    private let monitorQueue = DispatchQueue(label: "com.harbor.networkMonitor")
+    private var isMonitorStarted = false
+    private var hasReceivedInitialUpdate = false
+
+    /// Starts the network monitor if it is not already running.
+    /// Called lazily on the first connectivity check.
+    func start() {
+        guard !isMonitorStarted else { return }
+        isMonitorStarted = true
+
+        monitor.pathUpdateHandler = { _ in
+            Task { @HRequestManagerActor in
+                self.hasReceivedInitialUpdate = true
+            }
+        }
+        monitor.start(queue: monitorQueue)
+    }
+
+    /// Network connectivity check using NWPathMonitor.
+    func isConnectedToNetwork() -> Bool {
+        start()
+
+        // Fallback for debug/simulator environments
+        #if DEBUG || targetEnvironment(simulator)
+        let allowsDebugFallback = true
+        #else
+        let allowsDebugFallback = false
+        #endif
+
+        return Self.shouldAllowRequest(hasReceivedInitialUpdate: hasReceivedInitialUpdate,
+                                       pathStatus: monitor.currentPath.status,
+                                       allowsDebugFallback: allowsDebugFallback)
+    }
+
+    /// Decides whether a request should proceed based on the monitor state.
+    /// Until the monitor delivers its first path update the real status is unknown,
+    /// so connectivity is assumed instead of failing the request spuriously.
+    static func shouldAllowRequest(hasReceivedInitialUpdate: Bool, pathStatus: NWPath.Status, allowsDebugFallback: Bool) -> Bool {
+        guard hasReceivedInitialUpdate else { return true }
+
+        if pathStatus == .satisfied {
+            return true
+        }
+
+        return allowsDebugFallback
+    }
+}

--- a/Tests/HarborTests/HarborConnectivityTests.swift
+++ b/Tests/HarborTests/HarborConnectivityTests.swift
@@ -1,0 +1,110 @@
+//
+//  HarborConnectivityTests.swift
+//  Harbor
+//
+//  Tests for the network connectivity pre-check (NWPathMonitor based).
+//
+
+import XCTest
+import Network
+@testable import Harbor
+
+@HRequestManagerActor
+final class HarborConnectivityTests: XCTestCase {
+
+    // MARK: - shouldAllowRequest decision logic
+
+    func testShouldAllowRequestBeforeInitialUpdate() async {
+        // Given the monitor has not delivered its first path update yet (status unknown),
+        // requests must proceed optimistically even without the debug fallback.
+        // Regression test: previously the first request after launch was rejected
+        // with .noConnection in Release builds.
+        let allowed = HRequestManagerMonitor.shouldAllowRequest(hasReceivedInitialUpdate: false,
+                                                         pathStatus: .unsatisfied,
+                                                         allowsDebugFallback: false)
+
+        XCTAssertTrue(allowed)
+    }
+
+    func testShouldAllowRequestWhenPathIsSatisfied() async {
+        let allowed = HRequestManagerMonitor.shouldAllowRequest(hasReceivedInitialUpdate: true,
+                                                         pathStatus: .satisfied,
+                                                         allowsDebugFallback: false)
+
+        XCTAssertTrue(allowed)
+    }
+
+    func testShouldBlockRequestWhenOfflineInRelease() async {
+        // Given a real offline reading after the initial update,
+        // requests must still be blocked when there is no debug fallback (Release).
+        let allowed = HRequestManagerMonitor.shouldAllowRequest(hasReceivedInitialUpdate: true,
+                                                         pathStatus: .unsatisfied,
+                                                         allowsDebugFallback: false)
+
+        XCTAssertFalse(allowed)
+    }
+
+    func testShouldAllowRequestWhenOfflineWithDebugFallback() async {
+        // Given a real offline reading, DEBUG/simulator builds keep the permissive fallback.
+        let allowed = HRequestManagerMonitor.shouldAllowRequest(hasReceivedInitialUpdate: true,
+                                                         pathStatus: .unsatisfied,
+                                                         allowsDebugFallback: true)
+
+        XCTAssertTrue(allowed)
+    }
+
+    func testShouldBlockRequestWhenRequiresConnectionInRelease() async {
+        // .requiresConnection keeps the previous behavior: treated as offline in Release.
+        let allowed = HRequestManagerMonitor.shouldAllowRequest(hasReceivedInitialUpdate: true,
+                                                         pathStatus: .requiresConnection,
+                                                         allowsDebugFallback: false)
+
+        XCTAssertFalse(allowed)
+    }
+
+    // MARK: - Integration
+
+    func testIsConnectedToNetworkReturnsTrueInDebug() async {
+        // In DEBUG the check always allows requests (fallback), starting the monitor lazily.
+        XCTAssertTrue(HRequestManager.connectivityMonitor.isConnectedToNetwork())
+    }
+
+    func testStartNetworkMonitorIsIdempotent() async {
+        // Starting the monitor multiple times must be safe.
+        HRequestManager.connectivityMonitor.start()
+        HRequestManager.connectivityMonitor.start()
+
+        XCTAssertTrue(HRequestManager.connectivityMonitor.isConnectedToNetwork())
+    }
+
+    func testRequestFailsWithNoConnectionWhenMonitorReportsOffline() async {
+        // Given a fake monitor that reports offline (bypasses the DEBUG fallback),
+        // the request pipeline must short-circuit with .noConnection without hitting the network.
+        HRequestManager.connectivityMonitor = FakeConnectivityMonitor(connected: false)
+        defer { HRequestManager.connectivityMonitor = HRequestManagerMonitor() }
+
+        await Harbor.removeAllMocks()
+        let response = await MockGetRequest<MockModel>(url: "https://example.com/users").request()
+
+        guard case .error(let error) = response, case .noConnection = error else {
+            XCTFail("Expected .noConnection but got: \(response)")
+            return
+        }
+    }
+}
+
+/// Fake connectivity monitor for tests: reports a fixed connectivity state.
+@HRequestManagerActor
+final class FakeConnectivityMonitor: HRequestManagerMonitorProtocol {
+    private let connected: Bool
+
+    init(connected: Bool) {
+        self.connected = connected
+    }
+
+    func start() {}
+
+    func isConnectedToNetwork() -> Bool {
+        connected
+    }
+}


### PR DESCRIPTION
## Fix 1 — False `.noConnection` on the first request (library)

`isConnectedToNetwork()` started the `NWPathMonitor` lazily and read `currentPath.status` synchronously, which is not `.satisfied` until the monitor delivers its first update **asynchronously**. In Release builds the first request after launch (e.g. from a SwiftUI `.task`) could be rejected with `.noConnection`; the DEBUG/simulator fallback masked the bug locally.

**Fix**: connectivity is assumed until the monitor's first path update arrives (`hasReceivedInitialUpdate`). After that, behavior is unchanged. Real outages still surface downstream as `URLError`. Resolves item #26 of `HARBOR_IMPROVEMENT_PLAN.md`.

The monitor is fully internal — no public API. It lives in `HRequestManagerMonitor`, a `final class` behind the internal `HRequestManagerMonitorProtocol`, owned by `HRequestManager` (`static var connectivityMonitor`) so tests can inject a fake.

## Fix 2 — Example app gave no feedback (Example)

Results were appended at the bottom of a long ScrollView, off-screen, and the navbar gear button only appended text to that same invisible section.

**Fix**: sticky output console pinned to the bottom (auto-scrolls to newest, with Clear button), and a real settings sheet from the gear button.

## Fix 3 — CI example-tests destination

The workflow targeted `iPhone 16e`, which only exists with the iOS 26.2 runtime on `macos-26`; with `OS:latest` (26.5) no device matched. Destination changed to `iPhone 17`.

## Tests

- New `HarborConnectivityTests` (8 tests): the full `shouldAllowRequest` decision matrix (including the regression: pre-initial-update is optimistic even without the debug fallback), monitor start idempotency, and an end-to-end request failing with `.noConnection` via an injected `FakeConnectivityMonitor`.
- `swift test`: **158 tests, 0 failures**.
- `xcodebuild test` (HarborExample): **4/4 passed**.
