### PR TITLE
Upgrade LogBird to 2.1.0, encapsulate logging behind HarborLogger and fix sensitive-data leaks in debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [UNRELEASED]
 
 ### Added
+- `HarborLogger` facade encapsulating LogBird (single logger instance + sensitive-key redaction) so LogBird is an internal implementation detail of Harbor (#57)
+- `Harbor.loggingSensitiveKeys(_:)` taking `HLoggingSensitiveKeyAction` (`.set`, `.add`, `.reset`, `.clear`) for sensitive-key redaction configuration (#57)
 - Cache system `HCache` with memory (L1) + disk (L2) storage (#39, #42)
 - `HCache.CacheType`: `.urlCache` (default, automatic ETag/304), `.custom` (manual TTL and size control), `.disabled` (#52)
 - Per-request `cacheType` override on GET requests (#52)
@@ -19,6 +21,9 @@
 - Claude AI skill documentation (#51)
 
 ### Changed
+- Upgraded LogBird dependency from 1.0.0 to 2.1.0; debug logging now uses typed `LBValue` metadata, the `LBExtraMessage(key:value:)` API and LogBird's layered sensitive-key action API (#57)
+- Harbor no longer registers its own sensitive keys: LogBird 2.1's expanded global defaults (`password`, `token`, `authorization`, `auth`, `secret`, `apikey`, `cookie`, `bearer`, `credentials`, `privatekey`) already cover HTTP auth fields via separator-insensitive matching. `Harbor.loggingSensitiveKeys(_:)` can still fully replace, extend, restore or clear them (previously `setSensitiveKeys` always merged `LogBird.defaultSensitiveKeys` and could not be disabled) (#57)
+- Debug logging is enabled by default in DEBUG builds and disabled in RELEASE; the gate is encapsulated in `HarborLogger` (#57)
 - Network monitoring migrated from SystemConfiguration to NWPathMonitor (#49)
 - SHA256 migrated from CommonCrypto to CryptoKit (#47)
 - Cache cleanup now runs in background (#48)
@@ -27,6 +32,8 @@
 - Documentation updates (#37, #41)
 
 ### Fixed
+- Sensitive keys now apply to Harbor's debug logger: they were previously set on `LogBird.shared` while debug logging used a separate `LogBird(subsystem:category:)` instance, so the Harbor HTTP keys never reached the logs (#57)
+- Removed global LogBird mutation side effect from `HConfig.init()`; redaction is now owned by `HarborLogger` (#57)
 - URL injection vulnerability: path and query parameters are now percent-encoded (#46)
 - `clearCache` uses the proper URLRequest for URLCache (#52)
 - 304 Not Modified handling (#52)

--- a/Example/HarborExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/HarborExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "58177ff3c4405d9070d4ac4a288272ee2f8fabf5aa8265b10ad954bc06ec4de4",
+  "originHash" : "cb6a99f9d4cd8473f0d5d1dc3ccfe75e9afb5dc71829f1107c49ecad22890645",
   "pins" : [
     {
       "identity" : "logbird",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/javiermanzo/LogBird",
       "state" : {
-        "revision" : "ecf012c3bf7170474946eb483f5e36dbb5df266c",
-        "version" : "1.0.0"
+        "revision" : "3f7331df016a16acadae21f3d1add82c66f08d29",
+        "version" : "2.1.0"
       }
     }
   ],

--- a/Harbor.podspec
+++ b/Harbor.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   s.source_files = 'Sources/Harbor/**/*'
 
-  s.dependency 'LogBird', '1.0'
+  s.dependency 'LogBird', '2.1.0'
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "982ae41d35e176a67c90166457f3410f9cb46a9adc2dd642136153e38ef5c4ef",
+  "originHash" : "8a1c017daa772264c33de5cbb816113f8970e2d6ed05e0f24f14260016d92a9c",
   "pins" : [
     {
       "identity" : "logbird",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/javiermanzo/LogBird",
       "state" : {
-        "revision" : "ecf012c3bf7170474946eb483f5e36dbb5df266c",
-        "version" : "1.0.0"
+        "revision" : "3f7331df016a16acadae21f3d1add82c66f08d29",
+        "version" : "2.1.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
 
     dependencies: [
-        .package(url: "https://github.com/javiermanzo/LogBird", exact: "1.0.0"),
+        .package(url: "https://github.com/javiermanzo/LogBird", exact: "2.1.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Harbor is a library for making API requests in Swift in a simple way using async
     - [AsyncThrowingStream Support](#asyncthrowingstream-support)
     - [Data Sources](#data-sources)
     - [Stream Usage Examples](#stream-usage-examples)
-    - [Debug](#debug)
+  - [Debug](#debug)
     - [Sensitive Data in Logs](#sensitive-data-in-logs)
-    - [JSON RPC](#json-rpc)
+  - [JSON RPC](#json-rpc)
     - [Installation](#installation-1)
     - [Configuration](#configuration-1)
       - [Set URL](#set-url)
@@ -538,6 +538,9 @@ await Harbor.loggingSensitiveKeys(.reset)
 await Harbor.loggingSensitiveKeys(.clear)
 ```
 
+**JSON response bodies** are also redacted in debug logs: when the response `Content-Type` is JSON (or the body looks like JSON), any key containing a sensitive key is printed as `<redacted>`, so login responses like `{"access_token": "...", "refresh_token": "..."}` don't leak tokens. Set `Harbor.setLogSensitiveHeaders(true)` to see the raw body.
+
+Note that matching is **substring-based**: a key is redacted when it contains any sensitive key. This means the `auth` default also matches keys like `author` or `oauth` in response bodies, which will show as `<redacted>` in debug logs even though they are not credentials.
 
 ## JSON RPC
 Harbor also supports JSON RPC via the `HarborJRPC` package.

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ Harbor is a library for making API requests in Swift in a simple way using async
     - [AsyncThrowingStream Support](#asyncthrowingstream-support)
     - [Data Sources](#data-sources)
     - [Stream Usage Examples](#stream-usage-examples)
-  - [Debug](#debug)
-  - [JSON RPC](#json-rpc)
+    - [Debug](#debug)
+    - [Sensitive Data in Logs](#sensitive-data-in-logs)
+    - [JSON RPC](#json-rpc)
     - [Installation](#installation-1)
     - [Configuration](#configuration-1)
       - [Set URL](#set-url)
@@ -491,6 +492,12 @@ private func loadUsers() async {
 ### Debug
 You can print debug information about your request using the `HDebugRequestProtocol` protocol. Implement the protocol in the request class.
 
+Debug logging is enabled by default in `#if DEBUG` builds and disabled in release builds. You can configure it programmatically:
+
+```swift
+await Harbor.setLoggingEnabled(true) // or false to turn off debug logging
+```
+
 ```swift
 class MyRequest: HRequestWithResultProtocol, HDebugRequestProtocol {
     var debugType: HDebugRequestType = .requestAndResponse
@@ -503,14 +510,34 @@ class MyRequest: HRequestWithResultProtocol, HDebugRequestProtocol {
 
 When your request is called, you will see in the Xcode console the information about your request.
 
-#### Sensitive Data in Logs
+### Sensitive Data in Logs
+Harbor redacts sensitive data from debug logs and generated cURL commands through two complementary mechanisms:
 
-By default, Harbor redacts sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`, `X-API-Key`, `Proxy-Authorization`) and cookies from debug logs and generated cURL commands, printing `<redacted>` instead of the real value.
+**Header values** (`Authorization`, `Cookie`, `Set-Cookie`, `X-API-Key`, `Proxy-Authorization`) and cookies are printed as `<redacted>` in cURL output and the structured `headerParameters` log. Matching is case-insensitive.
 
 ```swift
-// Print real values (only for advanced debugging, never in production)
+// Print real header values (only for advanced debugging, never in production)
 await Harbor.setLogSensitiveHeaders(true)
 ```
+
+**Metadata keys** (in `additionalInfo`, `extraMessages` and error `userInfo`) are redacted automatically via [LogBird](https://github.com/javiermanzo/LogBird). Harbor inherits LogBird's global default keys (`password`, `token`, `authorization`, `auth`, `secret`, `apikey`, `cookie`, `bearer`, `credentials`, `privatekey`), whose separator-insensitive matching already covers HTTP auth fields like `set-cookie`, `x-api-key`, `access_token`, `refresh_token` and `private_key`. Matching is case-insensitive and ignores separators, so `accessToken`, `access-token` and `ACCESS_TOKEN` all match `token`.
+
+Actions are configured via `HLoggingSensitiveKeyAction`:
+
+```swift
+// Replace the full set (LogBird's defaults are NOT merged back in)
+await Harbor.loggingSensitiveKeys(.set(["signature", "otp"]))
+
+// Extend the current set, keeping the defaults
+await Harbor.loggingSensitiveKeys(.add(["signature", "otp"]))
+
+// Restore LogBird's defaults
+await Harbor.loggingSensitiveKeys(.reset)
+
+// Remove all keys, disabling redaction entirely (debug only)
+await Harbor.loggingSensitiveKeys(.clear)
+```
+
 
 ## JSON RPC
 Harbor also supports JSON RPC via the `HarborJRPC` package.

--- a/Sources/Harbor/Config/HConfig.swift
+++ b/Sources/Harbor/Config/HConfig.swift
@@ -15,7 +15,7 @@ struct HConfig: Sendable {
 
     /// Logger instance for configuration related events
     private static let logger = LogBird(subsystem: "com.harbor", category: "config")
-    
+
     /// Authentication provider for adding credentials to requests.
     var authProvider: HAuthProviderProtocol?
     /// Default headers applied to all requests.
@@ -36,8 +36,12 @@ struct HConfig: Sendable {
     var currentURLSession: URLSession?
     /// Whether mocks should only be enabled in DEBUG builds. Default is true.
     var mocksOnlyInDebug: Bool = true
-    /// Whether logging is enabled for debug purposes. Default is false.
+    /// Whether debug logging is enabled. Default is true in DEBUG builds, false in RELEASE builds.
+    #if DEBUG
+    var isLoggingEnabled: Bool = true
+    #else
     var isLoggingEnabled: Bool = false
+    #endif
     /// Whether sensitive header values are printed in debug logs and generated cURL commands. Default is false (redacted).
     var logSensitiveHeaders: Bool = false
     /// Header names treated as sensitive (lowercased) and redacted from debug output unless `logSensitiveHeaders` is true.

--- a/Sources/Harbor/Debug/HDebugRequestProtocol.swift
+++ b/Sources/Harbor/Debug/HDebugRequestProtocol.swift
@@ -47,6 +47,9 @@ extension HDebugRequestProtocol {
     /// Prints detailed request information to the console.
     /// - Parameter urlRequest: The URL request to debug.
     func logRequest(urlRequest: URLRequest) {
+        // Gate before building the payload: serializing parameters and
+        // generating the cURL is wasted work when logging is disabled.
+        guard HarborLogger.isLoggingEnabled else { return }
         if let request = self as? HRequestBaseRequestProtocol,
            self.debugType == .request || self.debugType == .requestAndResponse {
             var additionalInfo: [String: LBValue] = [:]
@@ -89,6 +92,9 @@ extension HDebugRequestProtocol {
     ///   - data: The response data.
     ///   - duration: The request duration in milliseconds.
     func logResponse(httpResponse: HTTPURLResponse, data: Data, duration: Double) {
+        // Gate before redacting/parsing the body: JSONSerialization of every
+        // response is wasted work when logging is disabled.
+        guard HarborLogger.isLoggingEnabled else { return }
         if self.debugType == .response || self.debugType == .requestAndResponse {
             var extraMessages: [LBExtraMessage] = []
             if let value = redactedResponseBody(data: data, httpResponse: httpResponse) {
@@ -112,6 +118,7 @@ extension HDebugRequestProtocol {
     /// swallowed; only the `isLoggingEnabled` gate applies.
     /// - Parameter error: The error that occurred during the request.
     func logErrorResponse(error: HRequestError) {
+        guard HarborLogger.isLoggingEnabled else { return }
         var extraMessages: [LBExtraMessage] = []
 
         extraMessages.append(LBExtraMessage(key: "Error Type", value: "\(error)"))

--- a/Sources/Harbor/Debug/HDebugRequestProtocol.swift
+++ b/Sources/Harbor/Debug/HDebugRequestProtocol.swift
@@ -44,48 +44,43 @@ public enum HDebugRequestType: Sendable {
 @HRequestManagerActor
 extension HDebugRequestProtocol {
     
-    /// Shared logger instance for debug output using LogBird framework.
-    /// Uses "com.harbor" subsystem with "debugging" category for organized log filtering.
-    static var logger: LogBird { LogBird(subsystem: "com.harbor", category: "debugging") }
-    
     /// Prints detailed request information to the console.
     /// - Parameter urlRequest: The URL request to debug.
     func logRequest(urlRequest: URLRequest) {
-        #if DEBUG
-        guard HConfig.shared.isLoggingEnabled else { return }
         if let request = self as? HRequestBaseRequestProtocol,
            self.debugType == .request || self.debugType == .requestAndResponse {
-            var additionalInfo: [String: String] = [:]
-            additionalInfo["request"] = String(describing: type(of: self))
-            additionalInfo["url"] = urlRequest.url?.absoluteString
-            additionalInfo["httpMethod"] = request.httpMethod.rawValue
+            var additionalInfo: [String: LBValue] = [:]
+            additionalInfo["request"] = .string(String(describing: type(of: self)))
+            if let urlString = urlRequest.url?.absoluteString {
+                additionalInfo["url"] = .string(urlString)
+            }
+            additionalInfo["httpMethod"] = .string(request.httpMethod.rawValue)
             
             if let headers = dictionaryToJSONString(redactedHeaders(urlRequest.allHTTPHeaderFields)) {
-                additionalInfo["headerParameters"] = String(describing: headers)
+                additionalInfo["headerParameters"] = .string(headers)
             }
             
             if let pathParameters = dictionaryToJSONString(request.pathParameters) {
-                additionalInfo["pathParameters"] = String(describing: pathParameters)
+                additionalInfo["pathParameters"] = .string(pathParameters)
             }
             
             if let r = self as? (any HGetRequestProtocol),
                let queryParameters = dictionaryToJSONString(r.queryParameters) {
-                additionalInfo["queryParameters"] = queryParameters
+                additionalInfo["queryParameters"] = .string(queryParameters)
             }
             
             if let r = self as? (any HRequestWithBodyProtocol),
                let bodyParameters = dictionaryToJSONString(r.bodyParameters) {
-                additionalInfo["bodyParameters"] = bodyParameters
+                additionalInfo["bodyParameters"] = .string(bodyParameters)
             }
             
-            additionalInfo["needsAuth"] = String(describing: request.needsAuth)
+            additionalInfo["needsAuth"] = .bool(request.needsAuth)
             
             let curl = self.generateCurl(urlRequest: urlRequest)
-            let extraMessages: [LBExtraMessage] = [LBExtraMessage(title: "cURL", message: curl)]
+            let extraMessages: [LBExtraMessage] = [LBExtraMessage(key: "cURL", value: curl)]
             
-            Self.logger.log("Request \(String(describing: type(of: request)))", extraMessages: extraMessages, additionalInfo: additionalInfo, level: .debug)
+            HarborLogger.log("Request \(String(describing: type(of: request)))", extraMessages: extraMessages, additionalInfo: additionalInfo, level: .debug)
         }
-        #endif
     }
     
     /// Prints detailed response information to the console.
@@ -94,42 +89,36 @@ extension HDebugRequestProtocol {
     ///   - data: The response data.
     ///   - duration: The request duration in milliseconds.
     func logResponse(httpResponse: HTTPURLResponse, data: Data, duration: Double) {
-        #if DEBUG
-        guard HConfig.shared.isLoggingEnabled else { return }
         if self.debugType == .response || self.debugType == .requestAndResponse {
             var extraMessages: [LBExtraMessage] = []
             if let value = String(data: data, encoding: String.Encoding.ascii) {
-                extraMessages.append(LBExtraMessage(title: "Response Value", message: value))
+                extraMessages.append(LBExtraMessage(key: "Response Value", value: value))
             }
             
-            extraMessages.append(LBExtraMessage(title: "Response Object", message: httpResponse.debugDescription))
+            extraMessages.append(LBExtraMessage(key: "Response Object", value: httpResponse.debugDescription))
             
-            var additionalInfo: [String: String] = [:]
-            additionalInfo["request"] = String(describing: type(of: self))
-            additionalInfo["size"] = data.debugDescription
-            additionalInfo["duration"] = "\(String(format: "%.2f", duration))ms"
+            var additionalInfo: [String: LBValue] = [:]
+            additionalInfo["request"] = .string(String(describing: type(of: self)))
+            additionalInfo["size"] = .string(data.debugDescription)
+            additionalInfo["duration"] = .string("\(String(format: "%.2f", duration))ms")
             
-            Self.logger.log("Response \(String(describing: type(of: self)))", extraMessages: extraMessages, additionalInfo: additionalInfo, level: .debug)
+            HarborLogger.log("Response \(String(describing: type(of: self)))", extraMessages: extraMessages, additionalInfo: additionalInfo, level: .debug)
         }
-        #endif
     }
     
     /// Prints error response information to the console.
     /// - Parameter error: The error that occurred during the request.
     func logErrorResponse(error: HRequestError) {
-        #if DEBUG
-        guard HConfig.shared.isLoggingEnabled else { return }
         if self.debugType == .response || self.debugType == .requestAndResponse {
             var extraMessages: [LBExtraMessage] = []
             
-            extraMessages.append(LBExtraMessage(title: "Error Type", message: "\(error)"))
+            extraMessages.append(LBExtraMessage(key: "Error Type", value: "\(error)"))
             
-            var additionalInfo: [String: String] = [:]
-            additionalInfo["request"] = String(describing: type(of: self))
+            var additionalInfo: [String: LBValue] = [:]
+            additionalInfo["request"] = .string(String(describing: type(of: self)))
             
-            Self.logger.log("Response Error \(String(describing: type(of: self)))", extraMessages: extraMessages, additionalInfo: additionalInfo, level: .error)
+            HarborLogger.log("Response Error \(String(describing: type(of: self)))", extraMessages: extraMessages, additionalInfo: additionalInfo, level: .error)
         }
-        #endif
     }
     
     /// Converts a dictionary to a JSON string representation.
@@ -142,11 +131,7 @@ extension HDebugRequestProtocol {
             let jsonString = String(data: jsonData, encoding: .utf8)
             return jsonString
         } catch {
-            #if DEBUG
-            if HConfig.shared.isLoggingEnabled {
-                Self.logger.log("Error converting dictionary to JSON", error: error)
-            }
-            #endif
+            HarborLogger.log("Error converting dictionary to JSON", error: error)
             return nil
         }
     }

--- a/Sources/Harbor/Debug/HDebugRequestProtocol.swift
+++ b/Sources/Harbor/Debug/HDebugRequestProtocol.swift
@@ -91,7 +91,7 @@ extension HDebugRequestProtocol {
     func logResponse(httpResponse: HTTPURLResponse, data: Data, duration: Double) {
         if self.debugType == .response || self.debugType == .requestAndResponse {
             var extraMessages: [LBExtraMessage] = []
-            if let value = String(data: data, encoding: String.Encoding.ascii) {
+            if let value = redactedResponseBody(data: data, httpResponse: httpResponse) {
                 extraMessages.append(LBExtraMessage(key: "Response Value", value: value))
             }
             
@@ -107,18 +107,19 @@ extension HDebugRequestProtocol {
     }
     
     /// Prints error response information to the console.
+    ///
+    /// Errors are logged regardless of `debugType` so failures are never silently
+    /// swallowed; only the `isLoggingEnabled` gate applies.
     /// - Parameter error: The error that occurred during the request.
     func logErrorResponse(error: HRequestError) {
-        if self.debugType == .response || self.debugType == .requestAndResponse {
-            var extraMessages: [LBExtraMessage] = []
-            
-            extraMessages.append(LBExtraMessage(key: "Error Type", value: "\(error)"))
-            
-            var additionalInfo: [String: LBValue] = [:]
-            additionalInfo["request"] = .string(String(describing: type(of: self)))
-            
-            HarborLogger.log("Response Error \(String(describing: type(of: self)))", extraMessages: extraMessages, additionalInfo: additionalInfo, level: .error)
-        }
+        var extraMessages: [LBExtraMessage] = []
+
+        extraMessages.append(LBExtraMessage(key: "Error Type", value: "\(error)"))
+
+        var additionalInfo: [String: LBValue] = [:]
+        additionalInfo["request"] = .string(String(describing: type(of: self)))
+
+        HarborLogger.log("Response Error \(String(describing: type(of: self)))", extraMessages: extraMessages, additionalInfo: additionalInfo, level: .error)
     }
     
     /// Converts a dictionary to a JSON string representation.
@@ -211,5 +212,58 @@ extension HDebugRequestProtocol {
         headers?.reduce(into: [String: String]()) { result, header in
             result[header.key] = redactedHeaderValue(name: header.key, value: header.value)
         }
+    }
+
+    /// Builds the debug string for a response body, redacting sensitive values
+    /// when the body is JSON (e.g. login/refresh tokens) unless
+    /// `HConfig.logSensitiveHeaders` is enabled. Non-JSON bodies are returned
+    /// as-is; if JSON parsing fails the raw body is returned.
+    internal func redactedResponseBody(data: Data, httpResponse: HTTPURLResponse) -> String? {
+        guard let raw = String(data: data, encoding: .utf8) ?? String(data: data, encoding: .ascii) else { return nil }
+        if HConfig.shared.logSensitiveHeaders { return raw }
+
+        let contentType = (httpResponse.value(forHTTPHeaderField: "Content-Type") ?? "").lowercased()
+        guard contentType.contains("json") || Self.looksLikeJSON(raw),
+              let parsed = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) else {
+            return raw
+        }
+
+        let needles = HarborLogger.sensitiveKeys
+        let redacted = Self.redactJSONValue(parsed, needles: needles)
+        guard JSONSerialization.isValidJSONObject(redacted),
+              let redactedData = try? JSONSerialization.data(withJSONObject: redacted, options: []),
+              let redactedString = String(data: redactedData, encoding: .utf8) else {
+            return raw
+        }
+        return redactedString
+    }
+
+    /// True when `s` starts with `{` or `[` after trimming whitespace.
+    private static func looksLikeJSON(_ s: String) -> Bool {
+        let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.first == "{" || trimmed.first == "["
+    }
+
+    /// Recursively redacts sensitive values within a parsed JSON object/array.
+    /// A key is sensitive when it contains any of `needles` after normalization
+    /// (mirrors LogBird's matching).
+    private static func redactJSONValue(_ value: Any, needles: Set<String>) -> Any {
+        if let dict = value as? [String: Any] {
+            var result: [String: Any] = [:]
+            for (key, nested) in dict {
+                result[key] = isSensitiveKey(key, needles: needles) ? "<redacted>" : redactJSONValue(nested, needles: needles)
+            }
+            return result
+        } else if let array = value as? [Any] {
+            return array.map { redactJSONValue($0, needles: needles) }
+        }
+        return value
+    }
+
+    /// Normalizes `key` (lowercase, stripping `-`, `_` and whitespace) and
+    /// returns whether it contains any of `needles`.
+    private static func isSensitiveKey(_ key: String, needles: Set<String>) -> Bool {
+        let normalized = key.lowercased().filter { $0 != "_" && $0 != "-" && !$0.isWhitespace }
+        return needles.contains { normalized.contains($0) }
     }
 }

--- a/Sources/Harbor/Debug/HLoggingSensitiveKeyAction.swift
+++ b/Sources/Harbor/Debug/HLoggingSensitiveKeyAction.swift
@@ -1,0 +1,25 @@
+//
+//  HLoggingSensitiveKeyAction.swift
+//  Harbor
+//
+//  Created by Javier Manzo on 01/08/2026.
+//
+
+import Foundation
+
+/// Describes an update to Harbor's sensitive-key redaction set, used by
+/// ``Harbor/loggingSensitiveKeys(_:)``. Harbor's logger inherits LogBird's
+/// global default sensitive keys; these actions let you override, extend,
+/// restore or disable them for Harbor's logger.
+public enum HLoggingSensitiveKeyAction: Sendable {
+    /// Replaces the full sensitive-key set. LogBird's defaults are not merged
+    /// back in.
+    case set([String])
+    /// Appends keys to the current set, ignoring duplicates.
+    case add([String])
+    /// Restores LogBird's default sensitive-key set.
+    case reset
+    /// Removes all sensitive keys, disabling redaction. Useful when debugging
+    /// and you need to inspect tokens or credentials.
+    case clear
+}

--- a/Sources/Harbor/Debug/HarborLogger.swift
+++ b/Sources/Harbor/Debug/HarborLogger.swift
@@ -1,0 +1,85 @@
+//
+//  HarborLogger.swift
+//  Harbor
+//
+//  Created by Javier Manzo on 01/08/2026.
+//
+
+import Foundation
+import LogBird
+
+/// Harbor's logging facade over LogBird.
+///
+/// Centralizes the single ``LogBird`` instance the framework logs through and
+/// the sensitive-key redaction policy, so LogBird stays an internal
+/// implementation detail of Harbor instead of being configured from `HConfig`,
+/// `Harbor` and the debug protocol independently.
+///
+/// Configure redaction through the public `Harbor.loggingSensitiveKeys(_:)`
+/// entry point, which takes an `HLoggingSensitiveKeyAction` (`.set`, `.add`,
+/// `.reset`, `.clear`).
+@HRequestManagerActor
+enum HarborLogger {
+
+    // MARK: - Logger
+
+    /// Whether debug logging is currently enabled in Harbor's configuration.
+    static var isLoggingEnabled: Bool {
+        HConfig.shared.isLoggingEnabled
+    }
+
+    /// The single LogBird instance Harbor logs through, scoped to the
+    /// `com.harbor` subsystem with a `debugging` category so entries are
+    /// isolated in Console.app.
+    ///
+    /// It inherits LogBird's global default sensitive keys, whose expanded
+    /// 2.1.0 set already covers HTTP auth fields (`authorization`, `auth`,
+    /// `cookie`/`set-cookie`, `apikey`/`x-api-key`, `bearer`, `credentials`,
+    /// `token`/`access_token`/`refresh_token`, `privatekey`/`private_key`, …)
+    /// via case-insensitive, separator-insensitive matching, so Harbor does
+    /// not register any keys of its own.
+    static let logger = LogBird(subsystem: "com.harbor", category: "debugging")
+
+    // MARK: - Sensitive Keys
+
+    /// The keys currently treated as sensitive by Harbor's logger.
+    static var sensitiveKeys: Set<String> { logger.sensitiveKeys }
+
+    /// Applies a sensitive-key update to Harbor's logger, mapping Harbor's
+    /// public ``HLoggingSensitiveKeyAction`` to LogBird's action API.
+    static func sensitiveKeys(_ action: HLoggingSensitiveKeyAction) {
+        switch action {
+        case .set(let keys): logger.sensitiveKeys(.set(keys))
+        case .add(let keys): logger.sensitiveKeys(.add(keys))
+        case .reset:         logger.sensitiveKeys(.reset)
+        case .clear:         logger.sensitiveKeys(.clear)
+        }
+    }
+
+    // MARK: - Logging
+
+    /// Records a debug log entry through Harbor's logger if logging is enabled.
+    static func log(
+        _ message: String? = nil,
+        extraMessages: [LBExtraMessage]? = nil,
+        additionalInfo: [String: LBValue]? = nil,
+        error: Error? = nil,
+        level: LBLogLevel = .debug,
+        file: String = #fileID,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        guard isLoggingEnabled else { return }
+
+        logger.log(
+            message,
+            extraMessages: extraMessages,
+            additionalInfo: additionalInfo,
+            error: error,
+            level: level,
+            file: file,
+            function: function,
+            line: line
+        )
+    }
+}

--- a/Sources/Harbor/Harbor.swift
+++ b/Sources/Harbor/Harbor.swift
@@ -86,8 +86,8 @@ public extension Harbor {
     /// `access-token` and `ACCESS_TOKEN` all match `token`.
     ///
     /// Harbor starts from LogBird's global defaults, which already cover
-    /// common HTTP auth fields (`authorization`, `auth`, `cookie`, `apiKey`,
-    /// `bearer`, `credentials`, `token`, `password`, `secret`, `privateKey`).
+    /// common HTTP auth fields (`authorization`, `auth`, `cookie`, `apikey`,
+    /// `bearer`, `credentials`, `token`, `password`, `secret`, `privatekey`).
     ///
     /// Examples:
     /// ```swift
@@ -110,7 +110,6 @@ public extension Harbor {
         HConfig.shared.logSensitiveHeaders = enabled
     }
 }
-
 
 // MARK: - Mocking
 

--- a/Sources/Harbor/Harbor.swift
+++ b/Sources/Harbor/Harbor.swift
@@ -103,7 +103,8 @@ public extension Harbor {
     }
 
     /// Configures whether sensitive header values (Authorization, Cookie, Set-Cookie, X-API-Key,
-    /// Proxy-Authorization) are printed in debug logs and generated cURL commands.
+    /// Proxy-Authorization) and sensitive fields in JSON response bodies (e.g. `access_token`,
+    /// `refresh_token`) are printed in debug logs and generated cURL commands.
     /// - Parameter enabled: If true, real values are printed. If false (default), values are redacted as `<redacted>`.
     static func setLogSensitiveHeaders(_ enabled: Bool) {
         HConfig.shared.logSensitiveHeaders = enabled

--- a/Sources/Harbor/Harbor.swift
+++ b/Sources/Harbor/Harbor.swift
@@ -79,6 +79,29 @@ public extension Harbor {
         HConfig.shared.isLoggingEnabled = enabled
     }
 
+    /// Configures sensitive-key redaction for debug logs.
+    ///
+    /// A key is sensitive when it contains any of the configured values;
+    /// matching is case-insensitive and ignores separators, so `accessToken`,
+    /// `access-token` and `ACCESS_TOKEN` all match `token`.
+    ///
+    /// Harbor starts from LogBird's global defaults, which already cover
+    /// common HTTP auth fields (`authorization`, `auth`, `cookie`, `apiKey`,
+    /// `bearer`, `credentials`, `token`, `password`, `secret`, `privateKey`).
+    ///
+    /// Examples:
+    /// ```swift
+    /// await Harbor.loggingSensitiveKeys(.set(["signature", "otp"])) // replace the full set
+    /// await Harbor.loggingSensitiveKeys(.add(["signature"]))          // extend the current set
+    /// await Harbor.loggingSensitiveKeys(.reset)                       // restore the defaults
+    /// await Harbor.loggingSensitiveKeys(.clear)                       // disable redaction (debug)
+    /// ```
+    ///
+    /// - Parameter action: The update to apply to the sensitive-key set.
+    static func loggingSensitiveKeys(_ action: HLoggingSensitiveKeyAction) {
+        HarborLogger.sensitiveKeys(action)
+    }
+
     /// Configures whether sensitive header values (Authorization, Cookie, Set-Cookie, X-API-Key,
     /// Proxy-Authorization) are printed in debug logs and generated cURL commands.
     /// - Parameter enabled: If true, real values are printed. If false (default), values are redacted as `<redacted>`.
@@ -86,6 +109,7 @@ public extension Harbor {
         HConfig.shared.logSensitiveHeaders = enabled
     }
 }
+
 
 // MARK: - Mocking
 

--- a/Sources/Harbor/Mock/HMock.swift
+++ b/Sources/Harbor/Mock/HMock.swift
@@ -12,18 +12,18 @@ import Foundation
 @HRequestManagerActor
 public struct HMock {
     /// The request type to mock.
-    let request: HRequestBaseRequestProtocol.Type
+    public let request: HRequestBaseRequestProtocol.Type
     /// The HTTP status code to return.
-    let statusCode: Int
+    public let statusCode: Int
     /// Optional JSON response body.
-    let jsonResponse: String?
+    public let jsonResponse: String?
     /// Optional error to return instead of success.
-    let error: HRequestError?
+    public let error: HRequestError?
     /// Optional delay in seconds before returning the response.
-    let delay: Double?
+    public let delay: Double?
 
     /// The name of the request type being mocked.
-    var requestName: String {
+    public var requestName: String {
         "\(request.self)"
     }
 

--- a/Sources/HarborJRPC/Request/HJRPCResponse.swift
+++ b/Sources/HarborJRPC/Request/HJRPCResponse.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  HJRPCResponse.swift
 //  
 //
 //  Created by Javier Manzo on 30/07/2024.

--- a/Sources/HarborJRPC/Request/HJSONRPCResponse.swift
+++ b/Sources/HarborJRPC/Request/HJSONRPCResponse.swift
@@ -17,7 +17,16 @@ struct HJRPCResult<Model: HModel>: HModel {
 /// Represents a JSON-RPC error returned by the server.
 public struct HJRPCError: HModel {
     /// The error code as defined by the JSON-RPC specification.
-    let code: Int
+    public let code: Int
     /// A human-readable error message.
-    let message: String
+    public let message: String
+
+    /// Creates a new JSON-RPC error.
+    /// - Parameters:
+    ///   - code: The error code
+    ///   - message: The error message
+    public init(code: Int, message: String) {
+        self.code = code
+        self.message = message
+    }
 }

--- a/Tests/HarborTests/HarborDebugTests.swift
+++ b/Tests/HarborTests/HarborDebugTests.swift
@@ -414,7 +414,7 @@ final class HarborDebugTests: XCTestCase {
         await XCTAssertNoThrowAsync(await request.logErrorResponse(error: error))
     }
 
-    // MARK: - #47 logErrorResponse is not filtered by debugType
+    // MARK: - logErrorResponse is not filtered by debugType
 
     func testLogErrorResponseLogsEvenForNoneDebugType() async {
         await Harbor.setLoggingEnabled(true)
@@ -433,7 +433,7 @@ final class HarborDebugTests: XCTestCase {
         XCTAssertEqual(last.level, .error)
     }
 
-    // MARK: - #194 response body redaction
+    // MARK: - Response body redaction
 
     func testLogResponseRedactsSensitiveJSONBody() async {
         await Harbor.setLogSensitiveHeaders(false)

--- a/Tests/HarborTests/HarborDebugTests.swift
+++ b/Tests/HarborTests/HarborDebugTests.swift
@@ -413,6 +413,93 @@ final class HarborDebugTests: XCTestCase {
         
         await XCTAssertNoThrowAsync(await request.logErrorResponse(error: error))
     }
+
+    // MARK: - #47 logErrorResponse is not filtered by debugType
+
+    func testLogErrorResponseLogsEvenForNoneDebugType() async {
+        await Harbor.setLoggingEnabled(true)
+        await HarborLogger.logger.clearLogs()
+        addTeardownBlock { await HarborLogger.logger.clearLogs() }
+
+        let request = TestDebugRequest(debugType: .none)
+        await request.logErrorResponse(error: .noConnection)
+
+        let logs = await HarborLogger.logger.logs
+        guard let last = logs.last else {
+            XCTFail("Expected an error log regardless of debugType")
+            return
+        }
+        XCTAssertTrue(last.message?.contains("Response Error") == true)
+        XCTAssertEqual(last.level, .error)
+    }
+
+    // MARK: - #194 response body redaction
+
+    func testLogResponseRedactsSensitiveJSONBody() async {
+        await Harbor.setLogSensitiveHeaders(false)
+        await Harbor.setLoggingEnabled(true)
+        await HarborLogger.logger.clearLogs()
+        addTeardownBlock { await HarborLogger.logger.clearLogs() }
+
+        let body = #"{"access_token":"abc123","refresh_token":"def456","user":"johndoe"}"#
+        let data = body.data(using: .utf8)!
+        let response = HTTPURLResponse(url: URL(string: "https://api.example.com/login")!,
+                                       statusCode: 200, httpVersion: nil,
+                                       headerFields: ["Content-Type": "application/json"])!
+
+        let request = TestDebugRequest(debugType: .response)
+        await request.logResponse(httpResponse: response, data: data, duration: 12.0)
+
+        guard let last = await HarborLogger.logger.logs.last,
+              let responseValue = last.extraMessages?.first(where: { $0.key == "Response Value" })?.value else {
+            XCTFail("Expected a Response Value extra message")
+            return
+        }
+
+        XCTAssertTrue(responseValue.contains("<redacted>"), "Sensitive fields should be redacted")
+        XCTAssertFalse(responseValue.contains("abc123"), "access_token value must not leak")
+        XCTAssertFalse(responseValue.contains("def456"), "refresh_token value must not leak")
+        XCTAssertTrue(responseValue.contains("johndoe"), "Non-sensitive fields should be preserved")
+    }
+
+    func testLogResponseDoesNotRedactBodyWhenSensitiveHeadersEnabled() async {
+        await Harbor.setLogSensitiveHeaders(true)
+        await Harbor.setLoggingEnabled(true)
+        await HarborLogger.logger.clearLogs()
+        addTeardownBlock {
+            await Harbor.setLogSensitiveHeaders(false)
+            await HarborLogger.logger.clearLogs()
+        }
+
+        let body = #"{"access_token":"abc123"}"#
+        let data = body.data(using: .utf8)!
+        let response = HTTPURLResponse(url: URL(string: "https://api.example.com/login")!,
+                                       statusCode: 200, httpVersion: nil,
+                                       headerFields: ["Content-Type": "application/json"])!
+
+        let request = TestDebugRequest(debugType: .response)
+        await request.logResponse(httpResponse: response, data: data, duration: 12.0)
+
+        guard let responseValue = await HarborLogger.logger.logs.last?
+            .extraMessages?.first(where: { $0.key == "Response Value" })?.value else {
+            XCTFail("Expected a Response Value extra message")
+            return
+        }
+        XCTAssertTrue(responseValue.contains("abc123"), "Raw token should be visible when opt-in is on")
+    }
+
+    func testRedactedResponseBodyLeavesNonJSONUnchanged() async {
+        await Harbor.setLogSensitiveHeaders(false)
+        let request = TestDebugRequest(debugType: .response)
+        let body = "plain-body-without-tokens"
+        let data = body.data(using: .utf8)!
+        let response = HTTPURLResponse(url: URL(string: "https://api.example.com/")!,
+                                       statusCode: 200, httpVersion: nil,
+                                       headerFields: ["Content-Type": "text/plain"])!
+
+        let result = await request.redactedResponseBody(data: data, httpResponse: response)
+        XCTAssertEqual(result, body)
+    }
 }
 
 // MARK: - Test Models and Requests

--- a/Tests/HarborTests/HarborLogBirdTests.swift
+++ b/Tests/HarborTests/HarborLogBirdTests.swift
@@ -1,0 +1,208 @@
+//
+//  HarborLogBirdTests.swift
+//  Harbor
+//
+
+import XCTest
+import Combine
+import LogBird
+@testable import Harbor
+
+final class HarborLogBirdTests: XCTestCase {
+
+    private var cancellables = Set<AnyCancellable>()
+
+    override func setUp() async throws {
+        await Harbor.setLoggingEnabled(true)
+        await HarborLogger.logger.clearLogs()
+        await Harbor.loggingSensitiveKeys(.reset)
+    }
+
+    override func tearDown() async throws {
+        await Harbor.setLoggingEnabled(true)
+        await HarborLogger.logger.clearLogs()
+        await Harbor.loggingSensitiveKeys(.reset)
+        cancellables.removeAll()
+    }
+
+    // MARK: - Default Sensitive Keys
+
+    func testInheritsLogBirdDefaultSensitiveKeys() async {
+        // Harbor no longer registers its own keys: LogBird 2.1's expanded global
+        // defaults (password, token, authorization, auth, secret, apikey, cookie,
+        // bearer, credentials, privatekey) already cover HTTP auth fields.
+        let keys = await HarborLogger.sensitiveKeys
+        XCTAssertTrue(LogBird.defaultSensitiveKeys.isSubset(of: keys))
+    }
+
+    // MARK: - .set (replace semantics)
+
+    func testSetReplacesEntireSensitiveKeySet() async {
+        await Harbor.loggingSensitiveKeys(.set(["only_this"]))
+
+        let keys = await HarborLogger.sensitiveKeys
+        // Keys are normalized at insertion (lowercased, stripping -, _ and whitespace).
+        XCTAssertEqual(keys, Set(["onlythis"]))
+        XCTAssertFalse(keys.contains("token"), "Defaults should not be merged back in")
+        XCTAssertFalse(keys.contains("auth"))
+    }
+
+    func testClearDisablesRedactionForDebugging() async {
+        // Disabling redaction entirely so tokens are visible while debugging.
+        await Harbor.loggingSensitiveKeys(.clear)
+
+        let info: [String: LBValue] = [
+            "username": .string("johndoe"),
+            "authToken": .string("secret_bearer_token_12345"),
+            "password": .string("P@ssw0rd123!")
+        ]
+
+        await HarborLogger.log("Authentication Attempt", additionalInfo: info)
+
+        let logs = await HarborLogger.logger.logs
+        guard let lastLog = logs.last, let stored = lastLog.additionalInfo else {
+            XCTFail("Expected a recorded log with additionalInfo")
+            return
+        }
+
+        XCTAssertEqual(stored["username"]?.description, "johndoe")
+        XCTAssertEqual(stored["authToken"]?.description, "secret_bearer_token_12345",
+                       "Token should be visible when redaction is disabled")
+        XCTAssertEqual(stored["password"]?.description, "P@ssw0rd123!",
+                       "Password should be visible when redaction is disabled")
+    }
+
+    // MARK: - .add (extend semantics)
+
+    func testAddExtendsActiveSensitiveKeySet() async {
+        await Harbor.loggingSensitiveKeys(.add(["trace_id", "token"])) // "token" is already a default
+
+        let keys = await HarborLogger.sensitiveKeys
+        // Inserted keys are normalized (lowercased, stripping -, _ and whitespace).
+        XCTAssertTrue(keys.contains("traceid"), "trace_id should be normalized to traceid")
+        // Defaults are preserved when extending.
+        XCTAssertTrue(keys.contains("auth"))
+    }
+
+    // MARK: - .reset
+
+    func testResetRestoresLogBirdDefaults() async {
+        await Harbor.loggingSensitiveKeys(.set(["custom"]))
+        await Harbor.loggingSensitiveKeys(.reset)
+
+        let keys = await HarborLogger.sensitiveKeys
+        XCTAssertEqual(keys, LogBird.defaultSensitiveKeys)
+        XCTAssertTrue(keys.contains("auth"))
+        XCTAssertFalse(keys.contains("custom"))
+    }
+
+    // MARK: - Redaction reaches Harbor's logger (bug-fix coverage)
+
+    func testHarborLoggerRedactsHTTPAuthFields() async {
+        // LogBird 2.1's global defaults + separator-insensitive matching cover
+        // these HTTP fields, and Harbor's logger inherits them — so they are
+        // redacted on the same instance Harbor logs through.
+        let info: [String: LBValue] = [
+            "username": .string("johndoe"),
+            "set-cookie": .string("session=abc; Path=/"),
+            "x-api-key": .string("key_99887766"),
+            "authorization": .string("Bearer secret"),
+            "refresh_token": .string("rt_abcdef")
+        ]
+
+        await HarborLogger.log("Outbound Request", additionalInfo: info)
+
+        let logs = await HarborLogger.logger.logs
+        guard let lastLog = logs.last, let stored = lastLog.additionalInfo else {
+            XCTFail("Expected a recorded log with additionalInfo")
+            return
+        }
+
+        XCTAssertEqual(stored["username"]?.description, "johndoe")
+        XCTAssertEqual(stored["set-cookie"]?.description, "<redacted>")
+        XCTAssertEqual(stored["x-api-key"]?.description, "<redacted>")
+        XCTAssertEqual(stored["authorization"]?.description, "<redacted>")
+        XCTAssertEqual(stored["refresh_token"]?.description, "<redacted>")
+    }
+
+    // MARK: - Typed metadata (LBValue)
+
+    func testTypedLBValueMetadata() async {
+        let metadata: [String: LBValue] = [
+            "endpoint": .string("https://api.example.com/v1/data"),
+            "statusCode": .int(200),
+            "isSuccess": .bool(true),
+            "latency": .double(45.2)
+        ]
+        let extra = [LBExtraMessage(key: "Headers", value: "Content-Type: application/json")]
+
+        await HarborLogger.log("API Log", extraMessages: extra, additionalInfo: metadata, level: .info)
+
+        let logs = await HarborLogger.logger.logs
+        guard let log = logs.last else {
+            XCTFail("Log should exist")
+            return
+        }
+
+        XCTAssertEqual(log.level, .info)
+        XCTAssertEqual(log.extraMessages?.first?.key, "Headers")
+        XCTAssertEqual(log.extraMessages?.first?.value, "Content-Type: application/json")
+        if case .int(let code) = log.additionalInfo?["statusCode"] {
+            XCTAssertEqual(code, 200)
+        } else {
+            XCTFail("Expected .int statusCode")
+        }
+        if case .bool(let success) = log.additionalInfo?["isSuccess"] {
+            XCTAssertEqual(success, true)
+        } else {
+            XCTFail("Expected .bool isSuccess")
+        }
+    }
+
+    // MARK: - Combine publisher
+
+    func testLogsPublisherEmitsLogEvents() async {
+        let expectation = expectation(description: "Receive LBLogEvent.recorded event")
+
+        await HarborLogger.logger.logsPublisher
+            .sink { event in
+                switch event {
+                case .recorded(let log):
+                    if log.message == "Publisher Test Log" {
+                        expectation.fulfill()
+                    }
+                case .cleared:
+                    break
+                }
+            }
+            .store(in: &cancellables)
+
+        await HarborLogger.log("Publisher Test Log", level: .warning)
+
+        await fulfillment(of: [expectation], timeout: 2.0)
+    }
+
+    // MARK: - Logging Enabled / Disabled
+
+    func testLoggingDisabledSuppressesLogOutput() async {
+        await Harbor.setLoggingEnabled(false)
+        await HarborLogger.log("Should not be logged", level: .info)
+
+        let logs = await HarborLogger.logger.logs
+        XCTAssertTrue(logs.isEmpty, "No logs should be recorded when logging is disabled")
+    }
+
+    @HRequestManagerActor
+    private static func getIsLoggingEnabled() -> Bool {
+        HConfig.shared.isLoggingEnabled
+    }
+
+    func testDefaultIsLoggingEnabledInDebug() async {
+        let isEnabled = await Self.getIsLoggingEnabled()
+        #if DEBUG
+        XCTAssertTrue(isEnabled, "isLoggingEnabled should default to true in DEBUG builds")
+        #else
+        XCTAssertFalse(isEnabled, "isLoggingEnabled should default to false in RELEASE builds")
+        #endif
+    }
+}

--- a/skill/harbor/SKILL.md
+++ b/skill/harbor/SKILL.md
@@ -327,7 +327,7 @@ See [protocols.md](protocols.md) for detailed error handling examples.
 - **Minimum iOS**: 15.0
 - **Minimum macOS**: 14.0
 - **Swift Version**: 5.9+ (Swift 6 compatible)
-- **Dependencies**: LogBird 1.0.0
+- **Dependencies**: LogBird 2.1.0
 
 ## Additional Resources
 


### PR DESCRIPTION
## Summary

Upgrades Harbor's logging dependency from **LogBird 1.0.0 → 2.1.0**, migrates all logging integrations to the v2 API, and introduces a `HarborLogger` facade so LogBird becomes an internal implementation detail of Harbor. Also fixes sensitive-data leaks in debug logs. Built on top of `release/4.0.0` (includes #56).

### LogBird 2.1 migration
- `Package.swift` / `Harbor.podspec` dependency → `2.1.0`.
- `LBExtraMessage` `title:`/`message:` → `key:`/`value:`; typed `[String: LBValue]` metadata in `HDebugRequestProtocol`.
- Adopts LogBird 2.1's layered sensitive-key action API (`.set`/`.add`/`.reset`/`.clear`).

### `HarborLogger` facade (encapsulation)
- New `Sources/Harbor/Debug/HarborLogger.swift` owns the **single** `LogBird(subsystem: "com.harbor", category: "debugging")` instance the framework logs through (previously a fresh instance was allocated on every log call, with no shared history/redaction).
- Encapsulates the `isLoggingEnabled` gate: `HarborLogger.log(...)` early-returns when logging is disabled.
- `HConfig` and `Harbor` no longer `import LogBird` for the debug path.

### Sensitive-key redaction (configurable + bug fixes)
- **Bug fixed:** Harbor's HTTP keys were set on `LogBird.shared` while debug logging used a separate `LogBird(subsystem:category:)` instance, so `auth`, `bearer`, `set-cookie`, … **never reached the logs**. They now live on the same instance Harbor logs through.
- Removed the global-LogBird-mutation side effect from `HConfig.init()`; redaction is owned by `HarborLogger`.
- **Harbor no longer registers its own keys.** LogBird 2.1's expanded global defaults (`password`, `token`, `authorization`, `auth`, `secret`, `apikey`, `cookie`, `bearer`, `credentials`, `privatekey`) already cover HTTP auth fields via separator-insensitive matching.
- New public API: `Harbor.loggingSensitiveKeys(_:)` taking `HLoggingSensitiveKeyAction` (`.set` replaces, `.add` extends, `.reset` restores defaults, `.clear` disables redaction).
- **JSON response bodies are now redacted** in debug logs: keys containing a sensitive key (e.g. `access_token`, `refresh_token`) print as `<redacted>`. Opt out with `Harbor.setLogSensitiveHeaders(true)`. Matching is substring-based, so e.g. `author` also matches `auth` — documented in the README.

### Debug logging behavior
- `logErrorResponse` now logs regardless of `debugType` so failures are never silently swallowed.
- Debug logging is enabled by default in DEBUG builds and disabled in RELEASE.
- The `isLoggingEnabled` gate runs **before** any payload is built: no parameter serialization, cURL generation or response-body JSON parsing happens when logging is disabled (fixes the release overhead left by removing the `#if DEBUG` guards).

### Also in this PR
- `HMock` properties made `public`; `HJRPCError` made fully `public` with a public init.
- README: new *Sensitive Data in Logs* section, fixed TOC hierarchy.

### Tests
- Full suite green: **190 tests, 0 failures**.
- New `HarborLogBirdTests` (10 tests): default-key inheritance, `.set`/`.add`/`.reset`/`.clear` semantics, key normalization, redaction reaching Harbor's logger, typed `LBValue` metadata, Combine publisher, logging gate.
- New `HarborDebugTests` cases: error logging independent of `debugType`, JSON body redaction, opt-out via `setLogSensitiveHeaders`, non-JSON bodies untouched.
