### PR TITLE
Security hardening: mTLS, per-host SSL pinning, and auth header handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - `HarborJRPC.setURL(URL)` plus a validating `setURL(String)` overload that throws `HJRPCConfigurationError.invalidURL`, and `HarborJRPC.configure(url:jrpcVersion:)` to set both at once
 - `rawBody` in Harbor's `HRequestWithBodyProtocol` to send raw `Data` as the request body instead of `bodyParameters`
 - CocoaPods subspec `Harbor/JRPC` to integrate HarborJRPC via CocoaPods
-- `HMTLS` mTLS configuration taking a `passwordProvider` closure, so the P12 password is requested once when the identity is extracted instead of being retained; its description always redacts the password
+- `HMTLS` mTLS configuration taking an async throwing `passwordProvider` closure, so the P12 password is requested once when the identity is extracted instead of being retained; its description always redacts the password
 - `Harbor.setSSLPinningKeys(_:forHosts:)` to scope SSL pins to specific hosts; challenges from unconfigured hosts get the default URLSession handling
 - `Harbor.setHTTPShouldHandleCookies(_:)` to let requests handle cookies through the shared cookie storage (default `false`)
 
@@ -84,6 +84,7 @@
 - `HJRPCRequestProtocol.request()` now throws and returns the decoded `Model`; use `requestResult()` for the previous non-throwing `HJRPCResponse` behavior
 - `HJRPCRequestProtocol.retries` and `.headers` are now get-only
 - Internally built `URLSession`s now set `httpShouldSetCookies` from `Harbor.setHTTPShouldHandleCookies(_:)`; with the default `false`, `Set-Cookie` responses are not stored in the shared cookie storage unless cookie handling is enabled
+- `HMTLS.passwordProvider` is now `@Sendable () async throws -> String` (synchronous closures still satisfy the signature) and `extractIdentity` is `async`; a throwing provider surfaces as the new `HMTLSError.passwordProviderFailed`
 
 ## 3.0.0 - Response cases, Logging (2024-12-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 - `generateCurl` reads cookies and additional headers from Harbor's actual `URLSession` instead of `URLSession.shared` (#56)
 - False `.noConnection` on the first request in Release (#55)
 - Auth header injection and the 401 retry flow no longer mutate the caller's request object: the authorization header is applied to the built `URLRequest`, which also fixes auth for class-conformed requests and for requests that do not persist `headerParameters`
-- `PKCS12` parsing is now the throwing `PKCS12.parse(...)` with a typed `PKCS12Error` instead of a half-initialized object on failure, and every `SecPKCS12Import` failure status is logged (with its error message) when logging is enabled
+- `PKCS12` parsing is now the throwing `PKCS12.parse(...)` with a typed `PKCS12Error` instead of a half-initialized object on failure, and every `SecPKCS12Import` failure status is logged (with its error message) in debug builds when logging is enabled
 
 ### ⚠️ Breaking Changes
 - `HAuthProviderProtocol.getAuthorizationHeader()` now returns `HAuthorizationHeader?`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 - `HarborJRPC.setURL(URL)` plus a validating `setURL(String)` overload that throws `HJRPCConfigurationError.invalidURL`, and `HarborJRPC.configure(url:jrpcVersion:)` to set both at once
 - `rawBody` in Harbor's `HRequestWithBodyProtocol` to send raw `Data` as the request body instead of `bodyParameters`
 - CocoaPods subspec `Harbor/JRPC` to integrate HarborJRPC via CocoaPods
+- `HMTLS` mTLS configuration taking a `passwordProvider` closure, so the P12 password is requested once when the identity is extracted instead of being retained; its description always redacts the password
+- `Harbor.setSSLPinningKeys(_:forHosts:)` to scope SSL pins to specific hosts; challenges from unconfigured hosts get the default URLSession handling
+- `Harbor.setHTTPShouldHandleCookies(_:)` to let requests handle cookies through the shared cookie storage (default `false`)
 
 ### Changed
 - Upgraded LogBird dependency from 1.0.0 to 2.1.0; debug logging now uses typed `LBValue` metadata, the `LBExtraMessage(key:value:)` API and LogBird's layered sensitive-key action API (#57)
@@ -47,6 +50,10 @@
 - `cachedETag()` now also works with the `.urlCache` cache type (#58)
 - `clearCache()` now falls back to the global default cache type when the request does not specify one (#58)
 - `HJRPCRequestError` conforms to `LocalizedError` with human-readable descriptions, and includes new `invalidResponse` and `idMismatch` cases
+- `HAuthProviderProtocol.getAuthorizationHeader()` now returns `HAuthorizationHeader?`; returning `nil` sends the request without an authorization header
+- `Harbor.setMTLS(_:)` is now `async` and reads/imports the P12 file off the actor so in-flight requests are not blocked
+- SHA256 helpers renamed for clarity: `SHA256.sha256(data:)` → `sha256Base64(data:)`, `SHA256.hash(data:)` → `sha256Data(data:)`, `String.sha256Hash` → `String.sha256Hex`; the old names remain as deprecated shims
+- `Harbor.setSSlPinningKeys(_:)` renamed to `Harbor.setSSLPinningKeys(_:)` and `HmTLS` renamed to `HMTLS`; the old spellings are deprecated
 
 ### Fixed
 - Sensitive keys now apply to Harbor's debug logger: they were previously set on `LogBird.shared` while debug logging used a separate `LogBird(subsystem:category:)` instance, so the Harbor HTTP keys never reached the logs (#57)
@@ -62,8 +69,12 @@
 - `generateCurl` and the structured request debug log no longer leak credentials: sensitive headers and cookies are redacted as `<redacted>` by default (#56)
 - `generateCurl` reads cookies and additional headers from Harbor's actual `URLSession` instead of `URLSession.shared` (#56)
 - False `.noConnection` on the first request in Release (#55)
+- Auth header injection and the 401 retry flow no longer mutate the caller's request object: the authorization header is applied to the built `URLRequest`, which also fixes auth for class-conformed requests and for requests that do not persist `headerParameters`
+- `PKCS12` parsing is now the throwing `PKCS12.parse(...)` with a typed `PKCS12Error` instead of a half-initialized object on failure, and every `SecPKCS12Import` failure status is logged (with its error message) when logging is enabled
 
 ### ⚠️ Breaking Changes
+- `HAuthProviderProtocol.getAuthorizationHeader()` now returns `HAuthorizationHeader?`
+- `Harbor.setMTLS(_:)` is now `async throws` and takes the new `HMTLS` type (`HmTLS` remains as a deprecated alias)
 - `TimeInterval.none` renamed to `TimeInterval.noExpiration` (#58)
 - `Harbor.clearAllCache()` is now `async` (#58)
 - `Harbor.setSSlPinningSHA256(String?)` → `Harbor.setSSlPinningKeys([String]?)` (#42)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - `HJRPCRequestProtocol.parameters` is now the typed `HJRPCParams` enum (`.named` / `.positioned`) instead of `[String: Any]`, removing the need for `@unchecked Sendable` conformances on JRPC requests
 - `HJRPCRequestProtocol.request()` now throws and returns the decoded `Model`; use `requestResult()` for the previous non-throwing `HJRPCResponse` behavior
 - `HJRPCRequestProtocol.retries` and `.headers` are now get-only
+- Internally built `URLSession`s now set `httpShouldSetCookies` from `Harbor.setHTTPShouldHandleCookies(_:)`; with the default `false`, `Set-Cookie` responses are not stored in the shared cookie storage unless cookie handling is enabled
 
 ## 3.0.0 - Response cases, Logging (2024-12-25)
 

--- a/Example/HarborExample/Requests/AuthExamples.swift
+++ b/Example/HarborExample/Requests/AuthExamples.swift
@@ -15,9 +15,9 @@ final class TokenAuthProvider: HAuthProviderProtocol, @unchecked Sendable {
     private var accessToken: String?
     private var tokenExpiration: Date?
 
-    func getAuthorizationHeader() async -> HAuthorizationHeader {
+    func getAuthorizationHeader() async -> HAuthorizationHeader? {
         guard let token = accessToken else {
-            return HAuthorizationHeader(key: "", value: "")
+            return nil
         }
         return HAuthorizationHeader(key: "Authorization", value: "Bearer \(token)")
     }
@@ -56,9 +56,9 @@ final class OAuth2AuthProvider: HAuthProviderProtocol, @unchecked Sendable {
         self.tokenEndpoint = tokenEndpoint
     }
 
-    func getAuthorizationHeader() async -> HAuthorizationHeader {
+    func getAuthorizationHeader() async -> HAuthorizationHeader? {
         guard let token = accessToken else {
-            return HAuthorizationHeader(key: "", value: "")
+            return nil
         }
         return HAuthorizationHeader(key: "Authorization", value: "Bearer \(token)")
     }
@@ -139,7 +139,7 @@ final class APIKeyAuthProvider: HAuthProviderProtocol, @unchecked Sendable {
         self.headerName = headerName
     }
 
-    func getAuthorizationHeader() async -> HAuthorizationHeader {
+    func getAuthorizationHeader() async -> HAuthorizationHeader? {
         return HAuthorizationHeader(key: headerName, value: apiKey)
     }
 
@@ -162,9 +162,9 @@ final class CustomAuthProvider: HAuthProviderProtocol, @unchecked Sendable {
         self.baseURL = baseURL
     }
 
-    func getAuthorizationHeader() async -> HAuthorizationHeader {
+    func getAuthorizationHeader() async -> HAuthorizationHeader? {
         guard let token = token else {
-            return HAuthorizationHeader(key: "", value: "")
+            return nil
         }
 
         return HAuthorizationHeader(
@@ -209,4 +209,96 @@ final class CustomAuthProvider: HAuthProviderProtocol, @unchecked Sendable {
         // Clear auth provider from Harbor
         await Harbor.setAuthProvider(nil)
     }
+}
+
+
+// MARK: - Token Refresh Demo
+
+/// Token the demo auth provider starts with; the demo stub server rejects it.
+private let expiredDemoToken = "expired_demo_token"
+/// Token the provider gets by refreshing; the demo stub server accepts it.
+private let validDemoToken = "valid_demo_token"
+
+/// Auth provider for the token-refresh demo.
+///
+/// It starts holding an expired access token. The demo stub server rejects that token
+/// with a 401 and Harbor asks for the authorization header again before retrying the
+/// request. Being asked again for the same token is the signal that the server rejected
+/// it, so the provider refreshes the token and Harbor's automatic retry succeeds.
+final class RefreshingAuthProvider: HAuthProviderProtocol, @unchecked Sendable {
+    private var accessToken = expiredDemoToken
+    private var currentTokenWasSent = false
+    private(set) var refreshCount = 0
+
+    func getAuthorizationHeader() async -> HAuthorizationHeader? {
+        if currentTokenWasSent {
+            refreshAccessToken()
+        }
+        currentTokenWasSent = true
+        return HAuthorizationHeader(key: "Authorization", value: "Bearer \(accessToken)")
+    }
+
+    func authFailed() async {
+        // Called when Harbor cannot recover the request with a refreshed token.
+        print("Authentication failed: no fresh token available")
+    }
+
+    private func refreshAccessToken() {
+        // A real provider would call its token endpoint here.
+        accessToken = validDemoToken
+        refreshCount += 1
+    }
+
+    /// Restores the initial state so the demo can run again with an expired token.
+    func reset() {
+        accessToken = expiredDemoToken
+        currentTokenWasSent = false
+        refreshCount = 0
+    }
+}
+
+/// Local stub server for the token-refresh demo.
+///
+/// Registered as a global URLProtocol, it answers requests to `auth-demo.local`
+/// without touching the network: the expired demo token gets a 401 and the refreshed
+/// token gets a 200 with a small JSON body. Requests to any other host are untouched.
+final class AuthDemoStubProtocol: URLProtocol {
+    static let host = "auth-demo.local"
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == host
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+
+        let authorization = request.value(forHTTPHeaderField: "Authorization")
+        let statusCode = authorization == "Bearer \(validDemoToken)" ? 200 : 401
+
+        guard let response = HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        let body = statusCode == 200
+            ? "{\"message\": \"Secure data unlocked\"}"
+            : "{\"message\": \"Invalid or expired token\"}"
+        client?.urlProtocol(self, didLoad: Data(body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }

--- a/Example/HarborExample/Requests/ExampleRequests.swift
+++ b/Example/HarborExample/Requests/ExampleRequests.swift
@@ -250,6 +250,20 @@ struct GetPrivateDataRequest: HGetRequestProtocol {
     let needsAuth: Bool = true
 }
 
+/// Response of the token-refresh demo stub server.
+struct SecureDemoData: Codable, Sendable {
+    let message: String
+}
+
+/// Request to the token-refresh demo stub server; requires auth and skips the cache
+/// so every run exercises the full 401, refresh and retry flow.
+struct GetSecureDemoDataRequest: HGetRequestProtocol {
+    typealias Model = SecureDemoData
+    let url: String = "https://\(AuthDemoStubProtocol.host)/secure-data"
+    let needsAuth: Bool = true
+    let cacheType: HCache.CacheType? = .disabled
+}
+
 /// Request with custom headers
 struct GetDataWithHeadersRequest: HGetRequestProtocol {
     typealias Model = [User]

--- a/Example/HarborExample/Requests/MTLSRequest.swift
+++ b/Example/HarborExample/Requests/MTLSRequest.swift
@@ -7,6 +7,10 @@
 
 import Harbor
 
+/// GET request to certauth.cryptomix.com, a free public test server that requires a
+/// client TLS certificate and echoes the TLS connection and client certificate details
+/// back as JSON. The client identity is configured from the certificate.p12 bundled
+/// with the app (valid until December 15, 2026) before this request runs.
 struct MTLSRequest: HGetRequestProtocol {
     typealias Model = MtlsModel
     let url: String = "https://certauth.cryptomix.com/json"

--- a/Example/HarborExample/Requests/ServerCertificateFetcher.swift
+++ b/Example/HarborExample/Requests/ServerCertificateFetcher.swift
@@ -32,7 +32,23 @@ final class ServerCertificateFetcher: NSObject, URLSessionDelegate {
         return certificate
     }
 
-    private var serverCertificate: SecCertificate?
+    /// Guards `serverCertificateStorage`, which is written on the session's delegate queue
+    /// and read after the data task completes.
+    private let lock = NSLock()
+    private var serverCertificateStorage: SecCertificate?
+
+    private var serverCertificate: SecCertificate? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return serverCertificateStorage
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            serverCertificateStorage = newValue
+        }
+    }
 
     func urlSession(
         _ session: URLSession,

--- a/Example/HarborExample/Requests/ServerCertificateFetcher.swift
+++ b/Example/HarborExample/Requests/ServerCertificateFetcher.swift
@@ -1,0 +1,53 @@
+//
+//  ServerCertificateFetcher.swift
+//  HarborExample
+//
+//  Support for the SSL pinning demo
+//
+
+import Foundation
+
+/// Fetches a host's leaf certificate by opening a TLS connection, so a pin can be
+/// computed from the live certificate with `Harbor.computePin(for:)`.
+/// Trust evaluation is left to the default handling; the certificate is only observed.
+final class ServerCertificateFetcher: NSObject, URLSessionDelegate {
+    /// Returns the leaf certificate presented by the given host.
+    /// - Throws: `URLError.badURL` when the host is invalid, or
+    ///   `URLError.serverCertificateUntrusted` when no certificate could be read.
+    static func fetchCertificate(from host: String) async throws -> SecCertificate {
+        guard let url = URL(string: "https://\(host)/") else {
+            throw URLError(.badURL)
+        }
+
+        let fetcher = ServerCertificateFetcher()
+        let session = URLSession(configuration: .ephemeral, delegate: fetcher, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+
+        // The response itself is not needed; the TLS handshake delivers the certificate.
+        _ = try? await session.data(from: url)
+
+        guard let certificate = fetcher.serverCertificate else {
+            throw URLError(.serverCertificateUntrusted)
+        }
+        return certificate
+    }
+
+    private var serverCertificate: SecCertificate?
+
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let serverTrust = challenge.protectionSpace.serverTrust else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+
+        if let chain = SecTrustCopyCertificateChain(serverTrust) as? [SecCertificate] {
+            serverCertificate = chain.first
+        }
+        completionHandler(.performDefaultHandling, nil)
+    }
+}

--- a/Example/HarborExample/RequestsView.swift
+++ b/Example/HarborExample/RequestsView.swift
@@ -699,6 +699,8 @@ struct RequestsView: View {
                     switch mtlsError {
                     case .fileNotFound:
                         message = "certificate.p12 could not be read"
+                    case .passwordProviderFailed:
+                        message = "the P12 password could not be supplied"
                     case .invalidPassword:
                         message = "the P12 password was rejected"
                     case .invalidP12Format:

--- a/Example/HarborExample/RequestsView.swift
+++ b/Example/HarborExample/RequestsView.swift
@@ -21,6 +21,9 @@ struct RequestsView: View {
     // Auth provider for authenticated requests
     private let authProvider = TokenAuthProvider()
 
+    // Auth provider for the token-refresh demo (starts with an expired token)
+    private let refreshAuthProvider = RefreshingAuthProvider()
+
     init() {
         // Configure global settings on first appear
     }
@@ -51,8 +54,8 @@ struct RequestsView: View {
 
         // Configure mTLS (optional - requires certificate)
         // guard let url = Bundle.main.url(forResource: "certificate", withExtension: "p12") else { return }
-        // let mTLS = HmTLS(p12FileUrl: url, password: "password")
-        // await Harbor.setMTLS(mTLS)
+        // let mTLS = HMTLS(p12FileUrl: url) { "notapassword" }
+        // try await Harbor.setMTLS(mTLS)
     }
 
     var body: some View {
@@ -561,19 +564,24 @@ struct RequestsView: View {
 
     func performAuthWithRefresh() {
         addResult("=== Auth with Token Refresh ===")
+        // Route auth-demo.local through the local stub server (no network needed).
+        URLProtocol.registerClass(AuthDemoStubProtocol.self)
+        refreshAuthProvider.reset()
         performWithLoading {
-            // This would trigger authFailed() in the provider
-            // which could refresh the token
-            await Harbor.setAuthProvider(authProvider)
+            // The provider starts with an expired token that the stub server rejects
+            // with a 401; it then refreshes the token and Harbor retries automatically.
+            await Harbor.setAuthProvider(refreshAuthProvider)
 
-            let response = await GetPrivateDataRequest().request()
+            let response = await GetSecureDemoDataRequest().request()
 
             await MainActor.run {
                 switch response {
-                case .success(let user):
-                    addResult("After refresh - User: \(user.name)")
+                case .success(let data):
+                    addResult("Server rejected the expired token with 401")
+                    addResult("Provider refreshed the token; Harbor retried automatically")
+                    addResult("Retry succeeded: \(data.message)")
                 case .error(let error):
-                    addResult("Error (expected): \(error.localizedDescription)")
+                    addResult("Error: \(error.localizedDescription)")
                 }
             }
         }
@@ -674,6 +682,43 @@ struct RequestsView: View {
     func performMTLSRequest() {
         addResult("=== mTLS Request ===")
         performWithLoading {
+            // Load the client certificate bundled with the app and configure mTLS.
+            guard let p12URL = Bundle.main.url(forResource: "certificate", withExtension: "p12") else {
+                await MainActor.run {
+                    addResult("certificate.p12 not found in the app bundle")
+                }
+                return
+            }
+
+            do {
+                let mTLS = HMTLS(p12FileUrl: p12URL) { "notapassword" }
+                try await Harbor.setMTLS(mTLS)
+            } catch {
+                let message: String
+                if let mtlsError = error as? HMTLSError {
+                    switch mtlsError {
+                    case .fileNotFound:
+                        message = "certificate.p12 could not be read"
+                    case .invalidPassword:
+                        message = "the P12 password was rejected"
+                    case .invalidP12Format:
+                        message = "certificate.p12 is malformed"
+                    case .noIdentity:
+                        message = "certificate.p12 contains no identity"
+                    }
+                } else {
+                    message = error.localizedDescription
+                }
+                await MainActor.run {
+                    addResult("Could not configure mTLS: \(message)")
+                }
+                return
+            }
+
+            await MainActor.run {
+                addResult("Client identity loaded from certificate.p12")
+            }
+
             let response = await MTLSRequest().request()
 
             await MainActor.run {
@@ -690,15 +735,37 @@ struct RequestsView: View {
     func configureSSLPinning() {
         addResult("=== Configuring SSL Pinning ===")
         Task {
-            // Example: Add public key hashes for SSL pinning
-            // These would be the SHA256 hashes of your server's public keys
-            let pinningKeys = [
-                "YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg="
-            ]
+            let host = "jsonplaceholder.typicode.com"
+            do {
+                // Read the live server certificate and compute its pin.
+                let certificate = try await ServerCertificateFetcher.fetchCertificate(from: host)
+                guard let pin = await Harbor.computePin(for: certificate) else {
+                    await MainActor.run {
+                        addResult("Could not compute a pin for the server certificate")
+                    }
+                    return
+                }
+                await MainActor.run {
+                    addResult("Computed pin: \(pin)")
+                }
 
-            await Harbor.setSSlPinningKeys(pinningKeys)
-            await MainActor.run {
-                addResult("SSL Pinning configured with \(pinningKeys.count) key(s)")
+                // Pin only the demo host; other endpoints keep default validation.
+                await Harbor.setSSLPinningKeys([pin], forHosts: [host])
+
+                // Verify that a pinned request to the host succeeds.
+                let response = await GetUsersRequest().request()
+                await MainActor.run {
+                    switch response {
+                    case .success(let users):
+                        addResult("Pinned request to \(host) succeeded (\(users.count) users)")
+                    case .error(let error):
+                        addResult("Pinned request failed: \(error.localizedDescription)")
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    addResult("Could not fetch the server certificate: \(error.localizedDescription)")
+                }
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -164,8 +164,9 @@ You need to create a class that implements `HAuthProviderProtocol`:
 
 ```swift
 class MyAuthProvider: HAuthProviderProtocol {
-    func getAuthorizationHeader() async -> HAuthorizationHeader {
-        // Return a HAuthorizationHeader instance
+    func getAuthorizationHeader() async -> HAuthorizationHeader? {
+        // Return a HAuthorizationHeader instance, or nil when no credentials are
+        // available (the request is then sent without an authorization header)
     }
     
     func authFailed() async {
@@ -214,11 +215,11 @@ struct MyRequest: HGetRequestProtocol {
 #### mTLS Support
 Harbor supports mutual TLS (mTLS) for enhanced security in API requests. This feature allows clients to present certificates to the server, ensuring both the client and server authenticate each other.
 
-To set up mTLS, use the `setMTLS` method:
+To set up mTLS, use the `setMTLS` method. The P12 password is supplied through a provider closure, so it is requested once when the identity is extracted instead of being retained:
 
 ```swift
-let mTLS = HmTLS(p12FileUrl: yourP12FileUrl, password: "yourPassword")
-await Harbor.setMTLS(mTLS)
+let mTLS = HMTLS(p12FileUrl: yourP12FileUrl) { "yourPassword" }
+try await Harbor.setMTLS(mTLS)
 ```
 
 #### SSL Pinning
@@ -230,7 +231,7 @@ To generate a pin from a certificate you can use `Harbor.computePin(for:)`:
 
 ```swift
 if let pin = await Harbor.computePin(for: certificate) {
-    await Harbor.setSSlPinningKeys([pin])
+    await Harbor.setSSLPinningKeys([pin])
 }
 ```
 
@@ -244,14 +245,20 @@ openssl s_client -connect api.example.com:443 -servername api.example.com < /dev
   openssl base64
 ```
 
-To configure SSL Pinning, use the `setSSlPinningKeys` method. You can provide multiple keys to support key rotation. Malformed pins log a warning and are ignored during validation:
+To configure SSL Pinning, use the `setSSLPinningKeys` method. You can provide multiple keys to support key rotation. Malformed pins log a warning and are ignored during validation:
 
 ```swift
 let sslPinningKeys = [
     "YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg=", // current certificate
     "GNKGcGj1ue3yRYvqr9t/lz2nkzMU5VZK3QBILcvPJ8U="  // backup / next rotation
 ]
-await Harbor.setSSlPinningKeys(sslPinningKeys)
+await Harbor.setSSLPinningKeys(sslPinningKeys)
+```
+
+Pins can also be scoped to specific hosts; unconfigured hosts get the default URLSession handling:
+
+```swift
+await Harbor.setSSLPinningKeys(sslPinningKeys, forHosts: ["api.example.com"])
 ```
 
 #### Retry Configuration

--- a/Sources/Harbor/Auth/HAuthProviderProtocol.swift
+++ b/Sources/Harbor/Auth/HAuthProviderProtocol.swift
@@ -11,8 +11,10 @@ import Foundation
 /// Implement this protocol to provide custom authentication logic.
 public protocol HAuthProviderProtocol: Sendable {
     /// Returns the authorization header for the current request.
-    /// - Returns: An `HAuthorizationHeader` containing the key-value pair for authorization.
-    func getAuthorizationHeader() async -> HAuthorizationHeader
+    /// - Returns: An `HAuthorizationHeader` containing the key-value pair for authorization,
+    ///   or `nil` when no credentials are available. In that case the request is sent
+    ///   without an authorization header.
+    func getAuthorizationHeader() async -> HAuthorizationHeader?
     
     /// Called when authentication fails, allowing the provider to handle the failure.
     /// This method can be used to refresh tokens, show login screens, etc.

--- a/Sources/Harbor/Cache/HCache+Manager.swift
+++ b/Sources/Harbor/Cache/HCache+Manager.swift
@@ -474,14 +474,14 @@ private extension HCache {
     struct FileStorage {
         /// Generates the file URL for a cache entry based on its key hash.
         static func url(for key: String, in directory: URL) -> URL {
-            let hash = key.sha256Hash
+            let hash = key.sha256Hex
             // Using .cache extension to distinguish from legacy files
             return directory.appendingPathComponent(hash).appendingPathExtension("cache")
         }
 
         /// Generates URLs for legacy cache formats (data and metadata files).
         static func legacyUrls(for key: String, in directory: URL) -> (URL, URL) {
-            let hash = key.sha256Hash
+            let hash = key.sha256Hex
             let dataURL = directory.appendingPathComponent(hash)
             let metaURL = dataURL.appendingPathExtension("meta")
             return (dataURL, metaURL)

--- a/Sources/Harbor/Cache/HGetRequestProtocol+Cache.swift
+++ b/Sources/Harbor/Cache/HGetRequestProtocol+Cache.swift
@@ -11,14 +11,16 @@ public extension HGetRequestProtocol {
 
     /// Retrieves cached data for this request using the associated Model type.
     /// Works with both custom cache and URLCache types.
+    /// - Parameter authHeader: The authorization header sent with the request, so
+    ///   `Vary: Authorization` entries are keyed by the credential they were stored with.
     /// - Returns: The cached model if found and valid, `nil` otherwise.
-    func cache() async -> Model? {
+    func cache(authHeader: HAuthorizationHeader? = nil) async -> Model? {
         let effectiveCacheType = await effectiveCacheType()
 
         switch effectiveCacheType {
         case .custom(let config):
             guard let cacheKey = await cacheKey() else { return nil }
-            return await HCache.Manager.shared.getCachedData(forKey: cacheKey, type: Model.self, config: config, requestHeaders: await effectiveRequestHeaders())
+            return await HCache.Manager.shared.getCachedData(forKey: cacheKey, type: Model.self, config: config, requestHeaders: await effectiveRequestHeaders(authHeader: authHeader))
 
         case .urlCache(let urlCache, _):
             guard let urlRequest = await urlRequest() else { return nil }
@@ -38,10 +40,12 @@ public extension HGetRequestProtocol {
     /// - Parameters:
     ///   - data: The response data to cache.
     ///   - response: The HTTP response containing cache headers (optional).
-    func saveCache(_ data: Data, response: HTTPURLResponse?) async {
+    ///   - authHeader: The authorization header sent with the request, so
+    ///     `Vary: Authorization` entries are keyed by the credential they were stored with.
+    func saveCache(_ data: Data, response: HTTPURLResponse?, authHeader: HAuthorizationHeader? = nil) async {
         if case .custom(let config) = await effectiveCacheType(),
            let cacheKey = await cacheKey() {
-            await HCache.Manager.shared.storeData(data, forKey: cacheKey, config: config, response: response, requestHeaders: await effectiveRequestHeaders())
+            await HCache.Manager.shared.storeData(data, forKey: cacheKey, config: config, response: response, requestHeaders: await effectiveRequestHeaders(authHeader: authHeader))
         }
     }
 
@@ -86,11 +90,12 @@ public extension HGetRequestProtocol {
 
     /// Returns the cached body to satisfy a `304 Not Modified` response and refreshes the
     /// stored entry (timestamp, expiration and validators) from the revalidation headers.
-    func revalidatedCache(response: HTTPURLResponse?) async -> Model? {
+    /// - Parameter authHeader: The authorization header sent with the request (see `cache(authHeader:)`).
+    func revalidatedCache(response: HTTPURLResponse?, authHeader: HAuthorizationHeader? = nil) async -> Model? {
         switch await effectiveCacheType() {
         case .custom(let config):
             guard let cacheKey = await cacheKey(),
-                  let model = await HCache.Manager.shared.getRevalidatableCachedData(forKey: cacheKey, type: Model.self, requestHeaders: await effectiveRequestHeaders()) else { return nil }
+                  let model = await HCache.Manager.shared.getRevalidatableCachedData(forKey: cacheKey, type: Model.self, requestHeaders: await effectiveRequestHeaders(authHeader: authHeader)) else { return nil }
             await HCache.Manager.shared.refreshEntry(forKey: cacheKey, response: response, config: config)
             return model
 
@@ -106,10 +111,11 @@ public extension HGetRequestProtocol {
 
     /// Returns an expired cached body while its `stale-if-error` window still allows serving it.
     /// Only works with custom cache type.
-    func staleCacheOnError() async -> Model? {
+    /// - Parameter authHeader: The authorization header sent with the request (see `cache(authHeader:)`).
+    func staleCacheOnError(authHeader: HAuthorizationHeader? = nil) async -> Model? {
         guard case .custom = await effectiveCacheType(),
               let cacheKey = await cacheKey() else { return nil }
-        return await HCache.Manager.shared.getStaleOnErrorData(forKey: cacheKey, type: Model.self, requestHeaders: await effectiveRequestHeaders())
+        return await HCache.Manager.shared.getStaleOnErrorData(forKey: cacheKey, type: Model.self, requestHeaders: await effectiveRequestHeaders(authHeader: authHeader))
     }
 }
 
@@ -133,12 +139,16 @@ private extension HGetRequestProtocol {
     }
 
     /// Resolves the headers that will effectively be sent with this request: the global default
-    /// headers merged with the request-specific ones. Used to evaluate `Vary` consistently with
-    /// what is actually sent on the wire.
-    func effectiveRequestHeaders() async -> [String: String]? {
+    /// headers merged with the request-specific ones and the authorization header. Used to
+    /// evaluate `Vary` consistently with what is actually sent on the wire. The credential is
+    /// only used for vary-key computation; it is never logged.
+    func effectiveRequestHeaders(authHeader: HAuthorizationHeader?) async -> [String: String]? {
         var headers = await HConfig.shared.defaultHeaderParameters ?? [:]
         if let own = headerParameters {
             headers.merge(own) { _, new in new }
+        }
+        if let authHeader {
+            headers[authHeader.key] = authHeader.value
         }
         return headers.isEmpty ? nil : headers
     }

--- a/Sources/Harbor/Cache/HGetRequestProtocol+Cache.swift
+++ b/Sources/Harbor/Cache/HGetRequestProtocol+Cache.swift
@@ -13,6 +13,8 @@ public extension HGetRequestProtocol {
     /// Works with both custom cache and URLCache types.
     /// - Parameter authHeader: The authorization header sent with the request, so
     ///   `Vary: Authorization` entries are keyed by the credential they were stored with.
+    ///   When nil and the request needs auth, the header is resolved from the configured
+    ///   auth provider.
     /// - Returns: The cached model if found and valid, `nil` otherwise.
     func cache(authHeader: HAuthorizationHeader? = nil) async -> Model? {
         let effectiveCacheType = await effectiveCacheType()
@@ -42,6 +44,8 @@ public extension HGetRequestProtocol {
     ///   - response: The HTTP response containing cache headers (optional).
     ///   - authHeader: The authorization header sent with the request, so
     ///     `Vary: Authorization` entries are keyed by the credential they were stored with.
+    ///     When nil and the request needs auth, the header is resolved from the configured
+    ///     auth provider.
     func saveCache(_ data: Data, response: HTTPURLResponse?, authHeader: HAuthorizationHeader? = nil) async {
         if case .custom(let config) = await effectiveCacheType(),
            let cacheKey = await cacheKey() {
@@ -140,17 +144,29 @@ private extension HGetRequestProtocol {
 
     /// Resolves the headers that will effectively be sent with this request: the global default
     /// headers merged with the request-specific ones and the authorization header. Used to
-    /// evaluate `Vary` consistently with what is actually sent on the wire. The credential is
-    /// only used for vary-key computation; it is never logged.
+    /// evaluate `Vary` consistently with what is actually sent on the wire. When `authHeader`
+    /// is nil and the request needs auth, the header is resolved from the configured auth
+    /// provider so the vary-key matches the one the network flow stores; without a provider
+    /// the lookup proceeds without a header. The credential is only used for vary-key
+    /// computation; it is never logged.
     func effectiveRequestHeaders(authHeader: HAuthorizationHeader?) async -> [String: String]? {
         var headers = await HConfig.shared.defaultHeaderParameters ?? [:]
         if let own = headerParameters {
             headers.merge(own) { _, new in new }
         }
-        if let authHeader {
+        if let authHeader = await resolveAuthHeader(authHeader) {
             headers[authHeader.key] = authHeader.value
         }
         return headers.isEmpty ? nil : headers
+    }
+
+    /// Returns the given authorization header, or resolves it from the configured auth
+    /// provider when the request needs auth. Never fails: without a provider the cache
+    /// path proceeds without a header.
+    func resolveAuthHeader(_ authHeader: HAuthorizationHeader?) async -> HAuthorizationHeader? {
+        if let authHeader { return authHeader }
+        guard needsAuth else { return nil }
+        return await HConfig.shared.authProvider?.getAuthorizationHeader()
     }
 
     /// Generates a cache key for this request based on the complete URL.

--- a/Sources/Harbor/Cache/HGetRequestProtocol+Cache.swift
+++ b/Sources/Harbor/Cache/HGetRequestProtocol+Cache.swift
@@ -123,6 +123,17 @@ public extension HGetRequestProtocol {
     }
 }
 
+extension HGetRequestProtocol {
+    /// Returns an expired cached body while its `stale-if-error` window still allows serving it,
+    /// keyed only by the headers already present on the request: the auth provider is not
+    /// consulted. Only works with custom cache type.
+    func staleCacheOnErrorSkippingAuthResolution() async -> Model? {
+        guard case .custom = await effectiveCacheType(),
+              let cacheKey = await cacheKey() else { return nil }
+        return await HCache.Manager.shared.getStaleOnErrorData(forKey: cacheKey, type: Model.self, requestHeaders: await effectiveRequestHeaders(authHeader: nil, resolvingAuthHeader: false))
+    }
+}
+
 private extension HGetRequestProtocol {
 
     /// Resolves the effective cache type for this request.
@@ -147,25 +158,26 @@ private extension HGetRequestProtocol {
     /// evaluate `Vary` consistently with what is actually sent on the wire. When `authHeader`
     /// is nil and the request needs auth, the header is resolved from the configured auth
     /// provider so the vary-key matches the one the network flow stores; without a provider
-    /// the lookup proceeds without a header. The credential is only used for vary-key
-    /// computation; it is never logged.
-    func effectiveRequestHeaders(authHeader: HAuthorizationHeader?) async -> [String: String]? {
+    /// the lookup proceeds without a header. Pass `resolvingAuthHeader: false` to skip the
+    /// provider entirely. The credential is only used for vary-key computation; it is never
+    /// logged.
+    func effectiveRequestHeaders(authHeader: HAuthorizationHeader?, resolvingAuthHeader: Bool = true) async -> [String: String]? {
         var headers = await HConfig.shared.defaultHeaderParameters ?? [:]
         if let own = headerParameters {
             headers.merge(own) { _, new in new }
         }
-        if let authHeader = await resolveAuthHeader(authHeader) {
+        if let authHeader = await resolveAuthHeader(authHeader, enabled: resolvingAuthHeader) {
             headers[authHeader.key] = authHeader.value
         }
         return headers.isEmpty ? nil : headers
     }
 
     /// Returns the given authorization header, or resolves it from the configured auth
-    /// provider when the request needs auth. Never fails: without a provider the cache
-    /// path proceeds without a header.
-    func resolveAuthHeader(_ authHeader: HAuthorizationHeader?) async -> HAuthorizationHeader? {
+    /// provider when the request needs auth and resolution is enabled. Never fails: without
+    /// a provider the cache path proceeds without a header.
+    func resolveAuthHeader(_ authHeader: HAuthorizationHeader?, enabled: Bool = true) async -> HAuthorizationHeader? {
         if let authHeader { return authHeader }
-        guard needsAuth else { return nil }
+        guard enabled, needsAuth else { return nil }
         return await HConfig.shared.authProvider?.getAuthorizationHeader()
     }
 

--- a/Sources/Harbor/Config/HConfig.swift
+++ b/Sources/Harbor/Config/HConfig.swift
@@ -38,6 +38,9 @@ struct HConfig: Sendable {
     /// SSL pinning public key hashes scoped to specific hosts. When a host is present here,
     /// its pins take precedence over the global `sslPinningKeys`; challenges from hosts
     /// absent from this map fall back to the global pins or, when none are set, to default handling.
+    /// Host keys are normalized (lowercased, without a trailing root-label dot) when stored
+    /// and when looked up, matching how DNS names are resolved. Malformed pins (not base64
+    /// SHA-256 hashes) log a warning when set and are ignored during validation.
     var sslPinningKeysByHost: [String: [String]]? {
         didSet {
             if let sslPinningKeysByHost {

--- a/Sources/Harbor/Config/HConfig.swift
+++ b/Sources/Harbor/Config/HConfig.swift
@@ -30,9 +30,20 @@ struct HConfig: Sendable {
     /// Malformed pins (not base64 SHA-256 hashes) log a warning when set and are ignored during validation.
     var sslPinningKeys: [String]? {
         didSet {
-            guard let sslPinningKeys else { return }
-            for key in sslPinningKeys where !HSPKI.isValidPin(key) {
-                Self.logger.log("SSL pinning key \"\(key)\" is not a valid base64 SHA-256 hash and will never match. Pins must be base64(SHA256(SPKI)).", level: .warning)
+            if let sslPinningKeys {
+                Self.validatePins(sslPinningKeys)
+            }
+        }
+    }
+    /// SSL pinning public key hashes scoped to specific hosts. When a host is present here,
+    /// its pins take precedence over the global `sslPinningKeys`; challenges from hosts
+    /// absent from this map fall back to the global pins or, when none are set, to default handling.
+    var sslPinningKeysByHost: [String: [String]]? {
+        didSet {
+            if let sslPinningKeysByHost {
+                for keys in sslPinningKeysByHost.values {
+                    Self.validatePins(keys)
+                }
             }
         }
     }
@@ -57,6 +68,8 @@ struct HConfig: Sendable {
     /// Whether DEBUG/simulator builds assume network availability instead of trusting the
     /// connectivity monitor. Default is true; set to false to exercise `.noConnection` flows in debug.
     var assumeNetworkAvailableInDebug: Bool = true
+    /// Whether URLRequests handle cookies through the shared cookie storage. Default is false.
+    var httpShouldHandleCookies: Bool = false
     /// URLProtocol classes injected into internally built sessions, allowing networking
     /// to be stubbed per session instead of registering protocols globally.
     var protocolClasses: [AnyClass]?
@@ -68,5 +81,12 @@ struct HConfig: Sendable {
         #else
         return !mocksOnlyInDebug
         #endif
+    }
+
+    /// Logs a warning for every pin that is not a valid base64 SHA-256 hash.
+    private static func validatePins(_ keys: [String]) {
+        for key in keys where !HSPKI.isValidPin(key) {
+            Self.logger.log("SSL pinning key \"\(key)\" is not a valid base64 SHA-256 hash and will never match. Pins must be base64(SHA256(SPKI)).", level: .warning)
+        }
     }
 }

--- a/Sources/Harbor/Harbor.swift
+++ b/Sources/Harbor/Harbor.swift
@@ -37,7 +37,7 @@ public extension Harbor {
         let loggingEnabled = HConfig.shared.isLoggingEnabled
         do {
             let identity = try await Task.detached {
-                try mTLS.extractIdentity(loggingEnabled: loggingEnabled)
+                try await mTLS.extractIdentity(loggingEnabled: loggingEnabled)
             }.value
             HConfig.shared.mTLSIdentity = identity
             HRequestManager.invalidateURLSession()

--- a/Sources/Harbor/Harbor.swift
+++ b/Sources/Harbor/Harbor.swift
@@ -29,12 +29,17 @@ public extension Harbor {
     }
 
     /// Configures mutual TLS for client certificate authentication.
+    /// The P12 file is read and imported off the actor so in-flight requests are not blocked.
     /// - Parameter mTLS: The mTLS configuration.
     /// - Throws: `HMTLSError` when the identity could not be extracted from the P12
     ///   (file missing, wrong password, malformed, no identity). mTLS stays disabled in that case.
-    static func setMTLS(_ mTLS: HmTLS) throws {
+    static func setMTLS(_ mTLS: HMTLS) async throws {
+        let loggingEnabled = HConfig.shared.isLoggingEnabled
         do {
-            HConfig.shared.mTLSIdentity = try mTLS.extractIdentity(loggingEnabled: HConfig.shared.isLoggingEnabled)
+            let identity = try await Task.detached {
+                try mTLS.extractIdentity(loggingEnabled: loggingEnabled)
+            }.value
+            HConfig.shared.mTLSIdentity = identity
             HRequestManager.invalidateURLSession()
         } catch {
             HConfig.shared.mTLSIdentity = nil
@@ -52,10 +57,42 @@ public extension Harbor {
 
     /// Enables SSL pinning with SHA256 hashes of the certificate's SubjectPublicKeyInfo (SPKI),
     /// base64 encoded. Provide multiple keys to support key rotation (backup pins).
-    /// Use `Harbor.computePin(for:)` to generate pins from a certificate.
-    static func setSSlPinningKeys(_ sslPinningKeys: [String]?) {
+    /// The pins apply to every host. Use `Harbor.computePin(for:)` to generate pins from a certificate.
+    static func setSSLPinningKeys(_ sslPinningKeys: [String]?) {
         HConfig.shared.sslPinningKeys = sslPinningKeys
         HRequestManager.invalidateURLSession()
+    }
+
+    /// Enables SSL pinning scoped to specific hosts. Challenges from these hosts are
+    /// validated against the given pins; hosts not configured here fall back to the
+    /// global pins set with `setSSLPinningKeys(_:)` or, when none are set, to default handling.
+    /// Passing `nil` removes the pins for the given hosts.
+    /// - Parameters:
+    ///   - sslPinningKeys: The pins for the hosts, or `nil` to stop pinning them.
+    ///   - hosts: The hosts the pins apply to (matched against `URLProtectionSpace.host`).
+    static func setSSLPinningKeys(_ sslPinningKeys: [String]?, forHosts hosts: [String]) {
+        if let sslPinningKeys {
+            var keysByHost = HConfig.shared.sslPinningKeysByHost ?? [:]
+            for host in hosts {
+                keysByHost[host] = sslPinningKeys
+            }
+            HConfig.shared.sslPinningKeysByHost = keysByHost
+        } else {
+            guard var keysByHost = HConfig.shared.sslPinningKeysByHost else { return }
+            for host in hosts {
+                keysByHost.removeValue(forKey: host)
+            }
+            HConfig.shared.sslPinningKeysByHost = keysByHost.isEmpty ? nil : keysByHost
+        }
+        HRequestManager.invalidateURLSession()
+    }
+
+    /// Enables SSL pinning with SHA256 hashes of the certificate's SubjectPublicKeyInfo (SPKI),
+    /// base64 encoded. Provide multiple keys to support key rotation (backup pins).
+    /// Use `Harbor.computePin(for:)` to generate pins from a certificate.
+    @available(*, deprecated, renamed: "setSSLPinningKeys(_:)")
+    static func setSSlPinningKeys(_ sslPinningKeys: [String]?) {
+        setSSLPinningKeys(sslPinningKeys)
     }
 
     /// Computes the SSL pin for a certificate: `base64(SHA256(SPKI))`.
@@ -127,6 +164,12 @@ public extension Harbor {
     /// - Parameter enabled: If true, real values are printed. If false (default), values are redacted as `<redacted>`.
     static func setLogSensitiveHeaders(_ enabled: Bool) {
         HConfig.shared.logSensitiveHeaders = enabled
+    }
+
+    /// Configures whether requests handle cookies through the shared cookie storage.
+    /// Default is false.
+    static func setHTTPShouldHandleCookies(_ enabled: Bool) {
+        HConfig.shared.httpShouldHandleCookies = enabled
     }
 
     /// Configures whether DEBUG/simulator builds assume network availability instead of

--- a/Sources/Harbor/Harbor.swift
+++ b/Sources/Harbor/Harbor.swift
@@ -67,6 +67,8 @@ public extension Harbor {
     /// validated against the given pins; hosts not configured here fall back to the
     /// global pins set with `setSSLPinningKeys(_:)` or, when none are set, to default handling.
     /// Passing `nil` removes the pins for the given hosts.
+    /// Host names are normalized (lowercased, without a trailing root-label dot) before
+    /// being stored and matched against `URLProtectionSpace.host`.
     /// - Parameters:
     ///   - sslPinningKeys: The pins for the hosts, or `nil` to stop pinning them.
     ///   - hosts: The hosts the pins apply to (matched against `URLProtectionSpace.host`).
@@ -74,13 +76,18 @@ public extension Harbor {
         if let sslPinningKeys {
             var keysByHost = HConfig.shared.sslPinningKeysByHost ?? [:]
             for host in hosts {
-                keysByHost[host] = sslPinningKeys
+                let normalizedHost = HURLSessionDelegate.normalizedHost(host)
+                guard !normalizedHost.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    HLogger.log("SSL pinning host keys must not be empty", level: .warning)
+                    continue
+                }
+                keysByHost[normalizedHost] = sslPinningKeys
             }
             HConfig.shared.sslPinningKeysByHost = keysByHost
         } else {
             guard var keysByHost = HConfig.shared.sslPinningKeysByHost else { return }
             for host in hosts {
-                keysByHost.removeValue(forKey: host)
+                keysByHost.removeValue(forKey: HURLSessionDelegate.normalizedHost(host))
             }
             HConfig.shared.sslPinningKeysByHost = keysByHost.isEmpty ? nil : keysByHost
         }
@@ -170,6 +177,7 @@ public extension Harbor {
     /// Default is false.
     static func setHTTPShouldHandleCookies(_ enabled: Bool) {
         HConfig.shared.httpShouldHandleCookies = enabled
+        HRequestManager.invalidateURLSession()
     }
 
     /// Configures whether DEBUG/simulator builds assume network availability instead of

--- a/Sources/Harbor/Request/HRequestManager.swift
+++ b/Sources/Harbor/Request/HRequestManager.swift
@@ -48,8 +48,9 @@ extension HRequestManager {
             return await runAttempts(
                 request: request,
                 retryPolicy: retryPolicy,
+                authHeader: nil,
                 errorResponse: { .error($0) }
-            ) { currentRequest, canRetry in
+            ) { currentRequest, _, canRetry in
                 return await processResponse(model: model, request: currentRequest, statusCode: mock.statusCode, data: data, httpResponse: mockResponse, canRetry: canRetry)
             }
         }
@@ -64,17 +65,18 @@ extension HRequestManager {
             return .error(hError)
         }
 
-        switch await addAuthCredentialsIfNeeded(request) {
+        switch await authorizationHeaderIfNeeded(for: request) {
         case .failure(let hError):
             await logError(hError, request: request)
             return .error(hError)
-        case .success(let authedRequest):
+        case .success(let authHeader):
             return await runAttempts(
-                request: authedRequest,
+                request: request,
                 retryPolicy: retryPolicy,
+                authHeader: authHeader,
                 errorResponse: { .error($0) }
-            ) { currentRequest, canRetry in
-                return await executeOnce(model: model, request: currentRequest, canRetry: canRetry)
+            ) { currentRequest, currentAuthHeader, canRetry in
+                return await executeOnce(model: model, request: currentRequest, authHeader: currentAuthHeader, canRetry: canRetry)
             }
         }
     }
@@ -82,10 +84,10 @@ extension HRequestManager {
     /// Executes a single network attempt: builds the URLRequest, performs the call and
     /// processes the response. `canRetry` tells whether the loop can run another attempt,
     /// so retryable failures are reported as `.retry` only while attempts remain.
-    private static func executeOnce<Model: HModel, Request: HRequestWithResultProtocol>(model: Model.Type, request: Request, canRetry: Bool) async -> HAttemptOutcome<HResponseWithResult<Model>> {
+    private static func executeOnce<Model: HModel, Request: HRequestWithResultProtocol>(model: Model.Type, request: Request, authHeader: HAuthorizationHeader?, canRetry: Bool) async -> HAttemptOutcome<HResponseWithResult<Model>> {
         let urlRequest: URLRequest
         do {
-            urlRequest = try await HURLBuilder.buildUrlRequest(request: request)
+            urlRequest = try await HURLBuilder.buildUrlRequest(request: request, authHeader: authHeader)
         } catch let hError as HRequestError {
             await logError(hError, request: request)
             return .finish(.error(hError))
@@ -219,8 +221,9 @@ extension HRequestManager {
             return await runAttempts(
                 request: request,
                 retryPolicy: retryPolicy,
+                authHeader: nil,
                 errorResponse: { .error($0) }
-            ) { currentRequest, canRetry in
+            ) { currentRequest, _, canRetry in
                 return await processResponse(request: currentRequest, statusCode: mock.statusCode, data: data, canRetry: canRetry)
             }
         }
@@ -231,17 +234,18 @@ extension HRequestManager {
             return .error(hError)
         }
 
-        switch await addAuthCredentialsIfNeeded(request) {
+        switch await authorizationHeaderIfNeeded(for: request) {
         case .failure(let hError):
             await logError(hError, request: request)
             return .error(hError)
-        case .success(let authedRequest):
+        case .success(let authHeader):
             return await runAttempts(
-                request: authedRequest,
+                request: request,
                 retryPolicy: retryPolicy,
+                authHeader: authHeader,
                 errorResponse: { .error($0) }
-            ) { currentRequest, canRetry in
-                return await executeOnce(request: currentRequest, canRetry: canRetry)
+            ) { currentRequest, currentAuthHeader, canRetry in
+                return await executeOnce(request: currentRequest, authHeader: currentAuthHeader, canRetry: canRetry)
             }
         }
     }
@@ -249,10 +253,10 @@ extension HRequestManager {
     /// Executes a single network attempt: builds the URLRequest, performs the call and
     /// processes the response. `canRetry` tells whether the loop can run another attempt,
     /// so retryable failures are reported as `.retry` only while attempts remain.
-    private static func executeOnce<Request: HRequestWithEmptyResponseProtocol>(request: Request, canRetry: Bool) async -> HAttemptOutcome<HResponse> {
+    private static func executeOnce<Request: HRequestWithEmptyResponseProtocol>(request: Request, authHeader: HAuthorizationHeader?, canRetry: Bool) async -> HAttemptOutcome<HResponse> {
         let urlRequest: URLRequest
         do {
-            urlRequest = try await HURLBuilder.buildUrlRequest(request: request)
+            urlRequest = try await HURLBuilder.buildUrlRequest(request: request, authHeader: authHeader)
         } catch let hError as HRequestError {
             await logError(hError, request: request)
             return .finish(.error(hError))
@@ -330,18 +334,21 @@ extension HRequestManager {
 // MARK: - Request Builder Functions
 extension HRequestManager {
     /// Runs the retry loop, delegating each attempt to `executeAttempt`. Mocks, connectivity
-    /// checks and the initial auth injection are evaluated once by the caller, not per attempt.
+    /// checks and the initial auth header fetch are evaluated once by the caller, not per attempt.
     /// `errorResponse` builds the typed response for the cancellation and auth-giveup paths.
     ///
     /// `TypedRequest` preserves the concrete request type from the caller through the loop,
     /// so the executor closure receives the typed request without any existential cast.
+    /// The loop never mutates the request: the authorization header is carried alongside it
+    /// and applied to the built `URLRequest` by the executor.
     private static func runAttempts<TypedRequest: HRequestBaseRequestProtocol & Sendable, Response: Sendable>(
         request: TypedRequest,
         retryPolicy: HRetryPolicy?,
+        authHeader: HAuthorizationHeader?,
         errorResponse: @escaping (HRequestError) -> Response,
-        executeAttempt: @escaping (TypedRequest, Bool) async -> HAttemptOutcome<Response>
+        executeAttempt: @escaping (TypedRequest, HAuthorizationHeader?, Bool) async -> HAttemptOutcome<Response>
     ) async -> Response {
-        var currentRequest = request
+        var currentAuthHeader = authHeader
         var attempt = 1
         var authRetriesRemaining = maxAuthRetries
         let maxRetries = retryPolicy?.maxRetries ?? 0
@@ -349,7 +356,7 @@ extension HRequestManager {
         while true {
             guard !Task.isCancelled else {
                 let hError: HRequestError = .cancelled
-                await logError(hError, request: currentRequest)
+                await logError(hError, request: request)
                 return errorResponse(hError)
             }
 
@@ -359,91 +366,58 @@ extension HRequestManager {
 
             let canRetry = attempt <= maxRetries
 
-            switch await executeAttempt(currentRequest, canRetry) {
+            switch await executeAttempt(request, currentAuthHeader, canRetry) {
             case .finish(let response):
                 return response
             case .retry:
                 attempt += 1
             case .unauthorized:
-                switch await refreshAuthorization(for: currentRequest, authRetriesRemaining: authRetriesRemaining) {
-                case .retry(let refreshedRequest):
-                    currentRequest = refreshedRequest
+                switch await refreshAuthorization(usedHeader: currentAuthHeader, authRetriesRemaining: authRetriesRemaining) {
+                case .retry(let freshHeader):
+                    currentAuthHeader = freshHeader
                     authRetriesRemaining -= 1
                 case .giveUp(let hError):
-                    await logError(hError, request: currentRequest)
+                    await logError(hError, request: request)
                     return errorResponse(hError)
                 }
             }
         }
     }
 
-    /// Injects the provider's authorization header into requests that need auth.
-    /// Fails with `.authProviderNeeded` when no provider is configured and with
-    /// `.malformedRequest` when the request type does not persist header parameters,
-    /// which would otherwise send the request out unauthenticated.
-    ///
-    /// Generic over the request type so the caller preserves the concrete type and avoids
-    /// casting back through an existential.
-    static func addAuthCredentialsIfNeeded<P: HRequestBaseRequestProtocol>(_ request: P) async -> Result<P, HRequestError> {
-        guard request.needsAuth else { return .success(request) }
+    /// Fetches the provider's authorization header for requests that need auth.
+    /// Fails with `.authProviderNeeded` when the request needs auth but no provider is
+    /// configured. A provider returning `nil` means no credentials are available and the
+    /// request goes out without an authorization header.
+    static func authorizationHeaderIfNeeded<P: HRequestBaseRequestProtocol>(for request: P) async -> Result<HAuthorizationHeader?, HRequestError> {
+        guard request.needsAuth else { return .success(nil) }
 
-        guard let authCredential = await HConfig.shared.authProvider?.getAuthorizationHeader() else {
+        guard let authProvider = HConfig.shared.authProvider else {
             return .failure(.authProviderNeeded)
         }
 
-        var modifiedRequest = request
-        if modifiedRequest.headerParameters == nil {
-            modifiedRequest.headerParameters = [:]
-        }
-        modifiedRequest.headerParameters?[authCredential.key] = authCredential.value
-
-        guard modifiedRequest.headerParameters?[authCredential.key] == authCredential.value else {
-            return .failure(.malformedRequest(reason: "The request type does not persist header parameters"))
-        }
-
-        return .success(modifiedRequest)
+        return .success(await authProvider.getAuthorizationHeader())
     }
 
     /// Fetches the provider's authorization header once and compares it with the one the
     /// failed attempt used. A retry is offered only when auth attempts remain and the
-    /// provider issued a different header. If the previously-injected header is absent the
-    /// request type does not persist headers (programming error) and we surface it loudly
-    /// instead of returning `.authNeeded`, which would hide the real cause.
-    private static func refreshAuthorization<P: HRequestBaseRequestProtocol>(
-        for request: P,
+    /// provider issued a different header; a provider without credentials (a `nil` header)
+    /// cannot satisfy a 401, so the flow gives up with `.authNeeded`.
+    private static func refreshAuthorization(
+        usedHeader: HAuthorizationHeader?,
         authRetriesRemaining: Int
-    ) async -> HAuthRefresh<P> {
+    ) async -> HAuthRefresh {
         guard authRetriesRemaining > 0, let authProvider = HConfig.shared.authProvider else {
             await HConfig.shared.authProvider?.authFailed()
             return .giveUp(.authNeeded)
         }
 
-        let freshHeader = await authProvider.getAuthorizationHeader()
-
-        guard let usedAuthorization = request.headerParameters?[freshHeader.key] else {
-            // The header slot is missing: the request type's setter is a no-op (the loud-failure
-            // path of `addAuthCredentialsIfNeeded` should have caught this earlier, but a
-            // conformer that drops the value between attempts is still possible).
-            return .giveUp(.malformedRequest(reason: "The request type does not persist header parameters"))
-        }
-
-        guard usedAuthorization != freshHeader.value else {
+        guard let freshHeader = await authProvider.getAuthorizationHeader(),
+              freshHeader != usedHeader else {
             await authProvider.authFailed()
             return .giveUp(.authNeeded)
         }
 
-        var modifiedRequest = request
-        if modifiedRequest.headerParameters == nil {
-            modifiedRequest.headerParameters = [:]
-        }
-        modifiedRequest.headerParameters?[freshHeader.key] = freshHeader.value
-
-        guard modifiedRequest.headerParameters?[freshHeader.key] == freshHeader.value else {
-            // The request type does not persist header parameters, so the fresh credentials would go out missing.
-            return .giveUp(.malformedRequest(reason: "The request type does not persist header parameters"))
-        }
-
-        return .retry(modifiedRequest)
+        return .retry(freshHeader)
     }
 
 
@@ -576,9 +550,10 @@ extension HRequestManager {
         }
 
         // If mTLS or SSL pinning is configured, the session needs a delegate to validate challenges.
-        if HConfig.shared.mTLSIdentity != nil || HConfig.shared.sslPinningKeys != nil {
+        if HConfig.shared.mTLSIdentity != nil || HConfig.shared.sslPinningKeys != nil || HConfig.shared.sslPinningKeysByHost != nil {
             let sessionDelegate = HURLSessionDelegate(mTLSIdentity: HConfig.shared.mTLSIdentity,
-                                                      sslPinningKeys: HConfig.shared.sslPinningKeys)
+                                                      sslPinningKeys: HConfig.shared.sslPinningKeys,
+                                                      sslPinningKeysByHost: HConfig.shared.sslPinningKeysByHost)
             return URLSession(configuration: configuration, delegate: sessionDelegate, delegateQueue: nil)
         }
 
@@ -601,11 +576,11 @@ private enum HAttemptOutcome<Response: Sendable> {
 }
 
 /// Outcome of evaluating a 401 response against the auth provider. The retry case carries
-/// the request with the refreshed header applied, preserving the concrete request type so
-/// the loop does not need to cast back through an existential.
-private enum HAuthRefresh<Request: HRequestBaseRequestProtocol> {
-    /// The provider issued a different authorization header; retry with it applied to the request.
-    case retry(Request)
+/// the refreshed authorization header, which the loop applies to the next attempt's
+/// `URLRequest` without touching the request object.
+private enum HAuthRefresh {
+    /// The provider issued a different authorization header; retry with it applied.
+    case retry(HAuthorizationHeader)
     /// No further attempt is possible; finish with the given error.
     case giveUp(HRequestError)
 }

--- a/Sources/Harbor/Request/HRequestManager.swift
+++ b/Sources/Harbor/Request/HRequestManager.swift
@@ -56,9 +56,17 @@ extension HRequestManager {
         }
 
         if !connectivityMonitor.isConnectedToNetwork() {
-            if let getRequest = request as? any HGetRequestProtocol,
-               let stale = await getRequest.staleCacheOnError(authHeader: await cacheAuthHeader(for: request)) as? Model {
-                return .success(stale)
+            if let getRequest = request as? any HGetRequestProtocol {
+                // Two-step lookup: the first pass skips the auth provider, so entries not
+                // keyed by credential (the common case) are served without invoking provider
+                // code (e.g. a token refresh) while offline; only on a miss is the header
+                // resolved for credential-keyed (Vary: Authorization) variants.
+                if let stale = await getRequest.staleCacheOnErrorSkippingAuthResolution() as? Model {
+                    return .success(stale)
+                }
+                if let stale = await getRequest.staleCacheOnError(authHeader: await cacheAuthHeader(for: request)) as? Model {
+                    return .success(stale)
+                }
             }
             let hError: HRequestError = .noConnection
             await logError(hError, request: request)

--- a/Sources/Harbor/Request/HRequestManager.swift
+++ b/Sources/Harbor/Request/HRequestManager.swift
@@ -57,7 +57,7 @@ extension HRequestManager {
 
         if !connectivityMonitor.isConnectedToNetwork() {
             if let getRequest = request as? any HGetRequestProtocol,
-               let stale = await getRequest.staleCacheOnError() as? Model {
+               let stale = await getRequest.staleCacheOnError(authHeader: await cacheAuthHeader(for: request)) as? Model {
                 return .success(stale)
             }
             let hError: HRequestError = .noConnection
@@ -127,12 +127,13 @@ extension HRequestManager {
                                          statusCode: httpResponse.statusCode,
                                          data: data,
                                          httpResponse: httpResponse,
-                                         canRetry: canRetry)
+                                         canRetry: canRetry,
+                                         authHeader: authHeader)
         } catch let error as URLError {
             let isCancelled = error.code == .cancelled || Task.isCancelled
             if !isCancelled,
                let getRequest = request as? any HGetRequestProtocol,
-               let stale = await getRequest.staleCacheOnError() as? Model {
+               let stale = await getRequest.staleCacheOnError(authHeader: authHeader) as? Model {
                 return .finish(.success(stale))
             }
             let hError = HRequestError.mapURLError(error)
@@ -155,14 +156,15 @@ extension HRequestManager {
     }
 
     /// Processes the raw response for a model-returning request, decoding the payload or handling errors/revalidation.
-    private static func processResponse<Model: HModel, Request: HRequestWithResultProtocol>(model: Model.Type, request: Request, statusCode: Int, data: Data, httpResponse: HTTPURLResponse? = nil, canRetry: Bool = false) async -> HAttemptOutcome<HResponseWithResult<Model>> {
+    /// `authHeader` keys the custom-cache reads and writes so `Vary: Authorization` entries are per-credential.
+    private static func processResponse<Model: HModel, Request: HRequestWithResultProtocol>(model: Model.Type, request: Request, statusCode: Int, data: Data, httpResponse: HTTPURLResponse? = nil, canRetry: Bool = false, authHeader: HAuthorizationHeader? = nil) async -> HAttemptOutcome<HResponseWithResult<Model>> {
         switch statusCode {
         case 200 ... 299:
             do {
                 let parsedResponse = try request.parseData(data: data, model: model)
 
                 if let request = request as? any HGetRequestProtocol {
-                    await request.saveCache(data, response: httpResponse)
+                    await request.saveCache(data, response: httpResponse, authHeader: authHeader)
                 }
 
                 return .finish(.success(parsedResponse))
@@ -175,7 +177,7 @@ extension HRequestManager {
             // Not Modified — serve the cached body and refresh the stored entry.
             // (URLCache revalidates transparently at URLSession level; this branch handles the custom cache.)
             if let getRequest = request as? any HGetRequestProtocol,
-               let cachedAny = await getRequest.revalidatedCache(response: httpResponse),
+               let cachedAny = await getRequest.revalidatedCache(response: httpResponse, authHeader: authHeader),
                let cachedModel = cachedAny as? Model {
                 return .finish(.success(cachedModel))
             } else {
@@ -191,7 +193,7 @@ extension HRequestManager {
             }
             if statusCode >= 500,
                let getRequest = request as? any HGetRequestProtocol,
-               let stale = await getRequest.staleCacheOnError() as? Model {
+               let stale = await getRequest.staleCacheOnError(authHeader: authHeader) as? Model {
                 return .finish(.success(stale))
             }
             let hError: HRequestError = .api(statusCode: statusCode, data: data)
@@ -372,7 +374,7 @@ extension HRequestManager {
             case .retry:
                 attempt += 1
             case .unauthorized:
-                switch await refreshAuthorization(usedHeader: currentAuthHeader, authRetriesRemaining: authRetriesRemaining) {
+                switch await refreshAuthorization(needsAuth: request.needsAuth, usedHeader: currentAuthHeader, authRetriesRemaining: authRetriesRemaining) {
                 case .retry(let freshHeader):
                     currentAuthHeader = freshHeader
                     authRetriesRemaining -= 1
@@ -398,14 +400,26 @@ extension HRequestManager {
         return .success(await authProvider.getAuthorizationHeader())
     }
 
+    /// Resolves the authorization header for cache vary-key computation without failing the
+    /// flow: a missing provider must not turn a cache lookup into an error.
+    private static func cacheAuthHeader<P: HRequestBaseRequestProtocol>(for request: P) async -> HAuthorizationHeader? {
+        guard case .success(let authHeader) = await authorizationHeaderIfNeeded(for: request) else { return nil }
+        return authHeader
+    }
+
     /// Fetches the provider's authorization header once and compares it with the one the
     /// failed attempt used. A retry is offered only when auth attempts remain and the
     /// provider issued a different header; a provider without credentials (a `nil` header)
     /// cannot satisfy a 401, so the flow gives up with `.authNeeded`.
     private static func refreshAuthorization(
+        needsAuth: Bool,
         usedHeader: HAuthorizationHeader?,
         authRetriesRemaining: Int
     ) async -> HAuthRefresh {
+        // A request that opted out of auth has no credential to refresh: give up
+        // without consulting the provider.
+        guard needsAuth else { return .giveUp(.authNeeded) }
+
         guard authRetriesRemaining > 0, let authProvider = HConfig.shared.authProvider else {
             await HConfig.shared.authProvider?.authFailed()
             return .giveUp(.authNeeded)
@@ -463,6 +477,8 @@ extension HRequestManager {
         var timeoutInterval: TimeInterval
         /// The cache configuration for the session.
         var cache: CacheSignature
+        /// Whether the session handles cookies through the shared cookie storage.
+        var httpShouldHandleCookies: Bool
     }
 
     /// The currently cached URLSession for reuse.
@@ -521,7 +537,7 @@ extension HRequestManager {
             }
         }
 
-        return SessionSignature(timeoutInterval: timeoutInterval, cache: cache)
+        return SessionSignature(timeoutInterval: timeoutInterval, cache: cache, httpShouldHandleCookies: HConfig.shared.httpShouldHandleCookies)
     }
 
     /// Builds a new URLSession tailored to the request's configuration.
@@ -529,6 +545,9 @@ extension HRequestManager {
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = request.timeoutInterval ?? HConfig.shared.timeoutInterval
         configuration.timeoutIntervalForResource = request.timeoutInterval ?? HConfig.shared.timeoutInterval
+        // Cookie handling is governed at the session-configuration level on Darwin; the
+        // request-level flag set by HURLBuilder alone is not enough.
+        configuration.httpShouldSetCookies = HConfig.shared.httpShouldHandleCookies
 
         if let protocolClasses = HConfig.shared.protocolClasses {
             configuration.protocolClasses = protocolClasses

--- a/Sources/Harbor/Request/HURLSessionDelegate.swift
+++ b/Sources/Harbor/Request/HURLSessionDelegate.swift
@@ -41,12 +41,9 @@ final class HURLSessionDelegate: NSObject, URLSessionDelegate, @unchecked Sendab
             // Host-scoped pins take precedence; hosts without scoped pins use the global
             // ones. When neither applies, the host is not pinned and gets default handling.
             let pinningKeys = sslPinningKeysByHost?[Self.normalizedHost(challenge.protectionSpace.host)] ?? sslPinningKeys
-            if let pinningKeys, let result = processSSLPinning(challenge, sslPinningKeys: pinningKeys) {
-                return completionHandler(result.disposition, result.credential)
-            }
-            // If SSL pinning applies to this host but validation fails, reject
-            if pinningKeys != nil {
-                return completionHandler(.cancelAuthenticationChallenge, nil)
+            if let pinningKeys {
+                processSSLPinning(challenge, sslPinningKeys: pinningKeys, completionHandler: completionHandler)
+                return
             }
         }
 
@@ -79,13 +76,51 @@ final class HURLSessionDelegate: NSObject, URLSessionDelegate, @unchecked Sendab
         return HChallengeResult(disposition: .useCredential, credential: credential)
     }
 
-    private func processSSLPinning(_ challenge: URLAuthenticationChallenge, sslPinningKeys: [String]) -> HChallengeResult? {
+    /// Concurrent queue for server trust evaluation, keeping the potentially slow
+    /// evaluation off the session's serial delegate queue.
+    private static let trustEvaluationQueue = DispatchQueue(label: "harbor.ssl.trust-evaluation", qos: .userInitiated, attributes: .concurrent)
+
+    /// Answers a server-trust challenge against the configured pins. A challenge without
+    /// a server trust is cancelled; otherwise the trust is evaluated off the session's
+    /// serial delegate queue before matching the pins.
+    private func processSSLPinning(_ challenge: URLAuthenticationChallenge, sslPinningKeys: [String], completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
               let serverTrust = challenge.protectionSpace.serverTrust else {
-            return nil
+            return completionHandler(.cancelAuthenticationChallenge, nil)
         }
 
-        return matchPins(serverTrust: serverTrust, sslPinningKeys: sslPinningKeys)
+        evaluateAndMatchPins(serverTrust: serverTrust, sslPinningKeys: sslPinningKeys, completionHandler: completionHandler)
+    }
+
+    /// Evaluates the server trust asynchronously and answers with the pin-matching result:
+    /// `.cancelAuthenticationChallenge` when the trust chain is invalid, otherwise the
+    /// outcome of `matchPins(serverTrust:sslPinningKeys:)`. The synchronous evaluation
+    /// inside `matchPins` reuses the cached result of the asynchronous one.
+    func evaluateAndMatchPins(serverTrust: SecTrust, sslPinningKeys: [String], completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        let context = TrustEvaluationContext(serverTrust: serverTrust, completionHandler: completionHandler)
+
+        // SecTrustEvaluateAsyncWithError requires being invoked on the queue it is given.
+        Self.trustEvaluationQueue.async {
+            SecTrustEvaluateAsyncWithError(context.serverTrust, Self.trustEvaluationQueue) { serverTrust, success, error in
+                guard success else {
+                    if let error {
+                        Self.logger.log("SSL Trust Evaluation Failed", error: error, level: .error)
+                    }
+                    return context.completionHandler(.cancelAuthenticationChallenge, nil)
+                }
+
+                let result = self.matchPins(serverTrust: serverTrust, sslPinningKeys: sslPinningKeys)
+                context.completionHandler(result.disposition, result.credential)
+            }
+        }
+    }
+
+    /// Boxes the values handed to the trust-evaluation queue. Marked `@unchecked Sendable`:
+    /// a `SecTrust` is safe to evaluate from any queue and the challenge completion
+    /// handler may be invoked from any queue.
+    private struct TrustEvaluationContext: @unchecked Sendable {
+        let serverTrust: SecTrust
+        let completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     }
 
     /// Evaluates the server trust and checks its certificate chain against the configured

--- a/Sources/Harbor/Request/HURLSessionDelegate.swift
+++ b/Sources/Harbor/Request/HURLSessionDelegate.swift
@@ -40,7 +40,7 @@ final class HURLSessionDelegate: NSObject, URLSessionDelegate, @unchecked Sendab
         if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust {
             // Host-scoped pins take precedence; hosts without scoped pins use the global
             // ones. When neither applies, the host is not pinned and gets default handling.
-            let pinningKeys = sslPinningKeysByHost?[challenge.protectionSpace.host] ?? sslPinningKeys
+            let pinningKeys = sslPinningKeysByHost?[Self.normalizedHost(challenge.protectionSpace.host)] ?? sslPinningKeys
             if let pinningKeys, let result = processSSLPinning(challenge, sslPinningKeys: pinningKeys) {
                 return completionHandler(result.disposition, result.credential)
             }
@@ -52,6 +52,16 @@ final class HURLSessionDelegate: NSObject, URLSessionDelegate, @unchecked Sendab
 
         // Default handling for other authentication methods
         return completionHandler(.performDefaultHandling, nil)
+    }
+
+    /// Normalizes a host name for pin storage and lookup: DNS names are case-insensitive
+    /// and may carry a trailing root-label dot, so both spellings must match the same pins.
+    static func normalizedHost(_ host: String) -> String {
+        var normalized = host.lowercased()
+        if normalized.hasSuffix(".") {
+            normalized.removeLast()
+        }
+        return normalized
     }
 
     private func processCertificateChallenge(_ challenge: URLAuthenticationChallenge) -> HChallengeResult? {
@@ -75,7 +85,15 @@ final class HURLSessionDelegate: NSObject, URLSessionDelegate, @unchecked Sendab
             return nil
         }
 
-        // Evaluate server trust first
+        return matchPins(serverTrust: serverTrust, sslPinningKeys: sslPinningKeys)
+    }
+
+    /// Evaluates the server trust and checks its certificate chain against the configured
+    /// pins. Succeeds only when the trust chain is valid and any certificate in it matches
+    /// one of the pins; cancels otherwise. Malformed pins are ignored so they can never
+    /// produce accidental matches.
+    func matchPins(serverTrust: SecTrust, sslPinningKeys: [String]) -> HChallengeResult {
+        // Pins must never be matched against an untrusted chain.
         var error: CFError?
         guard SecTrustEvaluateWithError(serverTrust, &error) else {
             if let error = error {
@@ -84,14 +102,6 @@ final class HURLSessionDelegate: NSObject, URLSessionDelegate, @unchecked Sendab
             return (disposition: .cancelAuthenticationChallenge, credential: nil)
         }
 
-        return matchPins(serverTrust: serverTrust, sslPinningKeys: sslPinningKeys)
-    }
-
-    /// Checks the certificate chain of an already-trusted server trust against the
-    /// configured pins. Succeeds when any certificate in the chain matches one of the
-    /// pins; cancels otherwise. Malformed pins are ignored so they can never produce
-    /// accidental matches.
-    func matchPins(serverTrust: SecTrust, sslPinningKeys: [String]) -> HChallengeResult {
         let validPins = Set(sslPinningKeys.filter { HSPKI.isValidPin($0) }.map { HSPKI.normalizePin($0) })
         guard !validPins.isEmpty else {
             Self.logger.log("SSL Pinning Failed: no valid pins configured", level: .error)

--- a/Sources/Harbor/Request/HURLSessionDelegate.swift
+++ b/Sources/Harbor/Request/HURLSessionDelegate.swift
@@ -18,10 +18,12 @@ final class HURLSessionDelegate: NSObject, URLSessionDelegate, @unchecked Sendab
 
     private let mTLSIdentity: HMTLSIdentity?
     private let sslPinningKeys: [String]?
+    private let sslPinningKeysByHost: [String: [String]]?
 
-    init(mTLSIdentity: HMTLSIdentity?, sslPinningKeys: [String]?) {
+    init(mTLSIdentity: HMTLSIdentity?, sslPinningKeys: [String]?, sslPinningKeysByHost: [String: [String]]? = nil) {
         self.mTLSIdentity = mTLSIdentity
         self.sslPinningKeys = sslPinningKeys
+        self.sslPinningKeysByHost = sslPinningKeysByHost
     }
 
     func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
@@ -36,11 +38,14 @@ final class HURLSessionDelegate: NSObject, URLSessionDelegate, @unchecked Sendab
 
         // Handle server trust validation (SSL pinning)
         if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust {
-            if let sslPinningKeys, let result = processSSLPinning(challenge, sslPinningKeys: sslPinningKeys) {
+            // Host-scoped pins take precedence; hosts without scoped pins use the global
+            // ones. When neither applies, the host is not pinned and gets default handling.
+            let pinningKeys = sslPinningKeysByHost?[challenge.protectionSpace.host] ?? sslPinningKeys
+            if let pinningKeys, let result = processSSLPinning(challenge, sslPinningKeys: pinningKeys) {
                 return completionHandler(result.disposition, result.credential)
             }
-            // If SSL pinning is configured but validation fails, reject
-            if sslPinningKeys != nil {
+            // If SSL pinning applies to this host but validation fails, reject
+            if pinningKeys != nil {
                 return completionHandler(.cancelAuthenticationChallenge, nil)
             }
         }
@@ -53,11 +58,11 @@ final class HURLSessionDelegate: NSObject, URLSessionDelegate, @unchecked Sendab
         guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodClientCertificate else {
             return nil
         }
-        
+
         guard let mTLSIdentity = mTLSIdentity else {
             return nil
         }
-        
+
         let credential = URLCredential(identity: mTLSIdentity.identity,
                                        certificates: mTLSIdentity.certificateChain,
                                        persistence: .none)
@@ -69,7 +74,7 @@ final class HURLSessionDelegate: NSObject, URLSessionDelegate, @unchecked Sendab
               let serverTrust = challenge.protectionSpace.serverTrust else {
             return nil
         }
-        
+
         // Evaluate server trust first
         var error: CFError?
         guard SecTrustEvaluateWithError(serverTrust, &error) else {
@@ -78,8 +83,15 @@ final class HURLSessionDelegate: NSObject, URLSessionDelegate, @unchecked Sendab
             }
             return (disposition: .cancelAuthenticationChallenge, credential: nil)
         }
-        
-        // Ignore malformed pins so they can never produce accidental matches
+
+        return matchPins(serverTrust: serverTrust, sslPinningKeys: sslPinningKeys)
+    }
+
+    /// Checks the certificate chain of an already-trusted server trust against the
+    /// configured pins. Succeeds when any certificate in the chain matches one of the
+    /// pins; cancels otherwise. Malformed pins are ignored so they can never produce
+    /// accidental matches.
+    func matchPins(serverTrust: SecTrust, sslPinningKeys: [String]) -> HChallengeResult {
         let validPins = Set(sslPinningKeys.filter { HSPKI.isValidPin($0) }.map { HSPKI.normalizePin($0) })
         guard !validPins.isEmpty else {
             Self.logger.log("SSL Pinning Failed: no valid pins configured", level: .error)

--- a/Sources/Harbor/Request/HmTLS.swift
+++ b/Sources/Harbor/Request/HmTLS.swift
@@ -12,6 +12,8 @@ import Foundation
 public enum HMTLSError: Error, Sendable {
     /// The P12 file does not exist or could not be read.
     case fileNotFound
+    /// The password provider failed to supply a password.
+    case passwordProviderFailed
     /// The P12 password is incorrect.
     case invalidPassword
     /// The P12 data is malformed or could not be imported.
@@ -50,14 +52,16 @@ public struct HMTLS: Sendable {
     let p12FileUrl: URL
     /// Supplies the P12 password on demand. It is called once when the identity is
     /// extracted and the returned password is not retained, so the password is not
-    /// kept alive for the lifetime of this value.
-    let passwordProvider: @Sendable () -> String
+    /// kept alive for the lifetime of this value. The async signature accommodates
+    /// password sources that are themselves asynchronous, such as keychain wrappers,
+    /// biometric prompts or remote vaults.
+    let passwordProvider: @Sendable () async throws -> String
 
     /// Creates a new mTLS configuration.
     /// - Parameters:
     ///   - p12FileUrl: The URL to the P12 certificate file.
     ///   - passwordProvider: A closure that returns the password for the P12 certificate file.
-    public init(p12FileUrl: URL, passwordProvider: @escaping @Sendable () -> String) {
+    public init(p12FileUrl: URL, passwordProvider: @escaping @Sendable () async throws -> String) {
         self.p12FileUrl = p12FileUrl
         self.passwordProvider = passwordProvider
     }
@@ -72,15 +76,21 @@ public struct HMTLS: Sendable {
     }
 
     /// Extracts the client identity from the P12 file.
-    /// - Throws: `HMTLSError.fileNotFound` when the file cannot be read, `.invalidPassword`
-    ///   when the password is rejected, `.invalidP12Format` when the import fails for any
-    ///   other reason, or `.noIdentity` when the file holds no identity.
-    func extractIdentity(loggingEnabled: Bool = false) throws(HMTLSError) -> HMTLSIdentity {
+    /// - Throws: `HMTLSError.fileNotFound` when the file cannot be read, `.passwordProviderFailed`
+    ///   when the password provider throws, `.invalidPassword` when the password is rejected,
+    ///   `.invalidP12Format` when the import fails for any other reason, or `.noIdentity`
+    ///   when the file holds no identity.
+    func extractIdentity(loggingEnabled: Bool = false) async throws(HMTLSError) -> HMTLSIdentity {
         guard let p12Data = try? Data(contentsOf: p12FileUrl) else {
             throw HMTLSError.fileNotFound
         }
 
-        let password = passwordProvider()
+        let password: String
+        do {
+            password = try await passwordProvider()
+        } catch {
+            throw HMTLSError.passwordProviderFailed
+        }
 
         let p12Contents: PKCS12
         do {

--- a/Sources/Harbor/Request/HmTLS.swift
+++ b/Sources/Harbor/Request/HmTLS.swift
@@ -20,7 +20,13 @@ public enum HMTLSError: Error, Sendable {
     case noIdentity
 }
 
-/// A Sendable wrapper for SecIdentity
+/// A Sendable wrapper for SecIdentity.
+///
+/// `SecIdentity` and `SecCertificate` are CoreFoundation reference types: they are
+/// reference-counted, immutable after creation and safe to read from any thread, so
+/// passing this wrapper across concurrency domains never shares mutable state. The
+/// `@preconcurrency import Security` above accounts for the Security framework not
+/// yet annotating these types as `Sendable`.
 public struct HMTLSIdentity: Sendable {
     /// The core client identity.
     public let identity: SecIdentity
@@ -39,21 +45,32 @@ public struct HMTLSIdentity: Sendable {
 
 /// Configuration for mutual TLS (mTLS) authentication.
 /// Use this to configure client certificates for secure communication.
-public struct HmTLS: Sendable {
+public struct HMTLS: Sendable {
     /// The URL to the P12 certificate file.
     let p12FileUrl: URL
-    /// The password for the P12 certificate file.
-    let password: String
+    /// Supplies the P12 password on demand. It is called once when the identity is
+    /// extracted and the returned password is not retained, so the password is not
+    /// kept alive for the lifetime of this value.
+    let passwordProvider: @Sendable () -> String
 
     /// Creates a new mTLS configuration.
     /// - Parameters:
-    ///   - p12FileUrl: The URL to the P12 certificate file
-    ///   - password: The password for the P12 certificate file
-    public init(p12FileUrl: URL, password: String) {
+    ///   - p12FileUrl: The URL to the P12 certificate file.
+    ///   - passwordProvider: A closure that returns the password for the P12 certificate file.
+    public init(p12FileUrl: URL, passwordProvider: @escaping @Sendable () -> String) {
         self.p12FileUrl = p12FileUrl
-        self.password = password
+        self.passwordProvider = passwordProvider
     }
-    
+
+    /// Creates a new mTLS configuration with a fixed password.
+    /// - Parameters:
+    ///   - p12FileUrl: The URL to the P12 certificate file.
+    ///   - password: The password for the P12 certificate file.
+    @available(*, deprecated, message: "Use init(p12FileUrl:passwordProvider:) instead; it requests the password once when the identity is extracted instead of retaining it.")
+    public init(p12FileUrl: URL, password: String) {
+        self.init(p12FileUrl: p12FileUrl, passwordProvider: { password })
+    }
+
     /// Extracts the client identity from the P12 file.
     /// - Throws: `HMTLSError.fileNotFound` when the file cannot be read, `.invalidPassword`
     ///   when the password is rejected, `.invalidP12Format` when the import fails for any
@@ -63,10 +80,18 @@ public struct HmTLS: Sendable {
             throw HMTLSError.fileNotFound
         }
 
-        let p12Contents = PKCS12(p12Data: p12Data, password: password, loggingEnabled: loggingEnabled)
+        let password = passwordProvider()
 
-        guard p12Contents.importStatus == errSecSuccess else {
-            throw p12Contents.importStatus == errSecAuthFailed ? HMTLSError.invalidPassword : HMTLSError.invalidP12Format
+        let p12Contents: PKCS12
+        do {
+            p12Contents = try PKCS12.parse(p12Data: p12Data, password: password, loggingEnabled: loggingEnabled)
+        } catch {
+            switch error {
+            case .importFailed(let status):
+                throw status == errSecAuthFailed ? HMTLSError.invalidPassword : HMTLSError.invalidP12Format
+            case .malformedContents:
+                throw HMTLSError.invalidP12Format
+            }
         }
 
         guard let identity = p12Contents.identity else {
@@ -76,3 +101,13 @@ public struct HmTLS: Sendable {
         return HMTLSIdentity(identity: identity, certificateChain: p12Contents.certChain)
     }
 }
+
+extension HMTLS: CustomStringConvertible {
+    /// Redacted description; the password is never included.
+    public var description: String {
+        "HMTLS(p12: \(p12FileUrl.lastPathComponent), password: <redacted>)"
+    }
+}
+
+@available(*, deprecated, renamed: "HMTLS", message: "Use HMTLS with init(p12FileUrl:passwordProvider:) so the password is requested on demand instead of being retained.")
+public typealias HmTLS = HMTLS

--- a/Sources/Harbor/Utils/HSPKI.swift
+++ b/Sources/Harbor/Utils/HSPKI.swift
@@ -83,7 +83,7 @@ enum HSPKI {
         guard let spkiData = spkiData(for: certificate) else {
             return nil
         }
-        return SHA256.sha256(data: spkiData)
+        return SHA256.sha256Base64(data: spkiData)
     }
 
     /// Validates that a pin string is base64 decoding to exactly 32 bytes (SHA-256),

--- a/Sources/Harbor/Utils/HURLBuilder.swift
+++ b/Sources/Harbor/Utils/HURLBuilder.swift
@@ -13,10 +13,14 @@ enum HURLBuilder {
     ///
     /// For GET requests using the custom cache, the stored validators are injected as
     /// `If-None-Match` / `If-Modified-Since` so the server can answer `304 Not Modified`.
-    /// - Parameter request: The request conforming to HRequestBaseRequestProtocol.
+    /// - Parameters:
+    ///   - request: The request conforming to HRequestBaseRequestProtocol.
+    ///   - authHeader: The authorization header fetched from the auth provider, applied on
+    ///     top of the request's own headers. Injecting it here keeps the caller's request
+    ///     object untouched, which matters when the conformer is a reference type.
     /// - Returns: A configured URLRequest.
     /// - Throws: `HRequestError.malformedRequest` when the URL or the body cannot be built.
-    static func buildUrlRequest<P: HRequestBaseRequestProtocol>(request: P) async throws -> URLRequest {
+    static func buildUrlRequest<P: HRequestBaseRequestProtocol>(request: P, authHeader: HAuthorizationHeader? = nil) async throws -> URLRequest {
         let url: URL
 
         switch request.httpMethod {
@@ -32,8 +36,7 @@ enum HURLBuilder {
         var urlRequest = URLRequest(url: url)
 
         urlRequest.httpMethod = request.httpMethod.rawValue
-        // TODO: Move to a config class
-        urlRequest.httpShouldHandleCookies = false
+        urlRequest.httpShouldHandleCookies = await HConfig.shared.httpShouldHandleCookies
 
         if let request = request as? HRequestWithBodyProtocol {
             if let rawBody = request.rawBody {
@@ -62,6 +65,10 @@ enum HURLBuilder {
 
         if let requestHeaderParameters = request.headerParameters {
             urlRequest.allHTTPHeaderFields = mergeHeaderParameters(currentHeaders: urlRequest.allHTTPHeaderFields, newHeaders: requestHeaderParameters)
+        }
+
+        if let authHeader {
+            urlRequest.setValue(authHeader.value, forHTTPHeaderField: authHeader.key)
         }
 
         // Inject the stored validators as conditional headers for GET requests using the custom cache.

--- a/Sources/Harbor/Utils/PKCS12.swift
+++ b/Sources/Harbor/Utils/PKCS12.swift
@@ -8,80 +8,83 @@
 import Foundation
 import LogBird
 
+/// Errors thrown when parsing a PKCS#12 archive.
+enum PKCS12Error: Error, Equatable {
+    /// `SecPKCS12Import` rejected the archive; carries the returned status
+    /// (`errSecAuthFailed` for a wrong password, other codes for malformed data).
+    case importFailed(OSStatus)
+    /// The import reported success but the returned items are missing or malformed.
+    case malformedContents
+}
+
 /// Helper class to extract client identity and certificates from a PKCS#12 archive.
 final class PKCS12 {
 
     private static let logger = LogBird(subsystem: "com.harbor", category: "p12")
 
     /// The label of the imported item.
-    var label: String?
+    let label: String?
     /// The key identifier.
-    var keyID: NSData?
+    let keyID: NSData?
     /// The trust management object.
-    var trust: SecTrust?
+    let trust: SecTrust?
     /// The certificate chain including intermediate certificates.
-    var certChain: [SecCertificate]?
+    let certChain: [SecCertificate]?
     /// The extracted client identity.
-    var identity: SecIdentity?
-    /// Status returned by `SecPKCS12Import`; `errSecSuccess` when the import succeeded.
-    private(set) var importStatus: OSStatus
-    /// Whether debug logging is enabled for import failures.
-    var loggingEnabled: Bool
+    let identity: SecIdentity?
 
-    /// Initializes and attempts to parse the P12 data using the provided password.
+    private init(label: String?, keyID: NSData?, trust: SecTrust?, certChain: [SecCertificate]?, identity: SecIdentity?) {
+        self.label = label
+        self.keyID = keyID
+        self.trust = trust
+        self.certChain = certChain
+        self.identity = identity
+    }
+
+    /// Parses the P12 data using the provided password.
     /// - Parameters:
     ///   - p12Data: The PKCS#12 archive data.
     ///   - password: The password to decrypt the archive.
     ///   - loggingEnabled: If true, parsing failures are logged.
-    init(p12Data: Data, password: String, loggingEnabled: Bool = false) {
-        self.loggingEnabled = loggingEnabled
+    /// - Throws: `PKCS12Error.importFailed` with the `SecPKCS12Import` status when the
+    ///   archive is rejected, or `PKCS12Error.malformedContents` when the imported items
+    ///   cannot be read.
+    static func parse(p12Data: Data, password: String, loggingEnabled: Bool = false) throws(PKCS12Error) -> PKCS12 {
         let importPasswordOption: NSDictionary = [kSecImportExportPassphrase as NSString: password]
 
         var items: CFArray?
 
         let status = SecPKCS12Import(p12Data as NSData, importPasswordOption, &items)
-        self.importStatus = status
 
         guard status == errSecSuccess else {
-            if status == errSecAuthFailed {
-                #if DEBUG
-                if loggingEnabled {
-                    Self.logger.log("PKCS12: Incorrect password")
-                }
-                #endif
+            #if DEBUG
+            if loggingEnabled {
+                let message = SecCopyErrorMessageString(status, nil) as String? ?? "Unknown error"
+                Self.logger.log("PKCS12: import failed with status \(status): \(message)")
             }
-            return
+            #endif
+            throw .importFailed(status)
         }
 
-        guard let theItemsCFArray = items else {
+        guard let theItemsNSArray = items as NSArray?,
+              let dictArray = theItemsNSArray as? [[String: AnyObject]] else {
             #if DEBUG
             if loggingEnabled {
                 Self.logger.log("PKCS12: error loading items")
             }
             #endif
-            return
-        }
-        
-        let theItemsNSArray: NSArray = theItemsCFArray as NSArray
-
-        guard let dictArray = theItemsNSArray as? [[String: AnyObject]] else {
-            #if DEBUG
-            if loggingEnabled {
-                Self.logger.log("PKCS12: error loading items")
-            }
-            #endif
-            return
+            throw .malformedContents
         }
 
-        label = getValue(by: kSecImportItemLabel, dictionaryArray: dictArray)
-        keyID = getValue(by: kSecImportItemKeyID, dictionaryArray: dictArray)
-        trust = getValue(by: kSecImportItemTrust, dictionaryArray: dictArray)
-        certChain = getValue(by: kSecImportItemCertChain, dictionaryArray: dictArray)
-        identity = getValue(by: kSecImportItemIdentity, dictionaryArray: dictArray)
+        return PKCS12(label: getValue(by: kSecImportItemLabel, dictionaryArray: dictArray),
+                      keyID: getValue(by: kSecImportItemKeyID, dictionaryArray: dictArray),
+                      trust: getValue(by: kSecImportItemTrust, dictionaryArray: dictArray),
+                      certChain: getValue(by: kSecImportItemCertChain, dictionaryArray: dictArray),
+                      identity: getValue(by: kSecImportItemIdentity, dictionaryArray: dictArray))
     }
 
     /// Extracts a specific value from the array of dictionaries returned by `SecPKCS12Import`.
-    private func getValue<T>(by key: CFString, dictionaryArray: [[String: AnyObject]]) -> T? {
+    private static func getValue<T>(by key: CFString, dictionaryArray: [[String: AnyObject]]) -> T? {
         for dictionary in dictionaryArray {
             if let value = dictionary[key as String] as? T {
                 return value

--- a/Sources/Harbor/Utils/SHA256.swift
+++ b/Sources/Harbor/Utils/SHA256.swift
@@ -9,23 +9,41 @@ import Foundation
 import CryptoKit
 
 final class SHA256 {
-    static func sha256(data: Data) -> String {
+    /// Returns the SHA-256 digest of the data, base64 encoded. Used for SSL pinning pins.
+    static func sha256Base64(data: Data) -> String {
         let digest = CryptoKit.SHA256.hash(data: data)
         return Data(digest).base64EncodedString()
     }
-    
-    static func hash(data: Data) -> Data {
+
+    /// Returns the raw SHA-256 digest bytes of the data.
+    static func sha256Data(data: Data) -> Data {
         let digest = CryptoKit.SHA256.hash(data: data)
         return Data(digest)
+    }
+
+    @available(*, deprecated, renamed: "sha256Base64(data:)")
+    static func sha256(data: Data) -> String {
+        sha256Base64(data: data)
+    }
+
+    @available(*, deprecated, renamed: "sha256Data(data:)")
+    static func hash(data: Data) -> Data {
+        sha256Data(data: data)
     }
 }
 
 // MARK: - String Extension for Cache Keys
 
 extension String {
-    var sha256Hash: String {
+    /// Lowercase hex-encoded SHA-256 digest of the string's UTF-8 bytes. Used for cache keys.
+    var sha256Hex: String {
         let data = Data(self.utf8)
-        let hash = SHA256.hash(data: data)
+        let hash = SHA256.sha256Data(data: data)
         return hash.compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    @available(*, deprecated, renamed: "sha256Hex")
+    var sha256Hash: String {
+        sha256Hex
     }
 }

--- a/Tests/HarborTests/HURLSessionDelegateTests.swift
+++ b/Tests/HarborTests/HURLSessionDelegateTests.swift
@@ -39,9 +39,9 @@ final class HURLSessionDelegateTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func testMTLSChallengeSendsCertificateChain() throws {
+    func testMTLSChallengeSendsCertificateChain() async throws {
         // Given
-        let identity = try loadTestIdentity()
+        let identity = try await loadTestIdentity()
         let expectedChainCount = try XCTUnwrap(identity.certificateChain, "Identity should include the certificate chain").count
         XCTAssertGreaterThan(expectedChainCount, 0)
 
@@ -60,7 +60,7 @@ final class HURLSessionDelegateTests: XCTestCase {
             expectation.fulfill()
         }
 
-        wait(for: [expectation], timeout: 1.0)
+        await fulfillment(of: [expectation], timeout: 1.0)
     }
 
     // MARK: - SSL Pinning Challenge Tests
@@ -83,9 +83,9 @@ final class HURLSessionDelegateTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func testSSLPinningWithMatchingPinUsesCredential() throws {
+    func testSSLPinningWithMatchingPinUsesCredential() async throws {
         // Given a server trust whose leaf certificate matches the configured pin
-        let serverTrust = try makeServerTrust()
+        let serverTrust = try await makeServerTrust()
         let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: [testPin])
 
         // When
@@ -96,9 +96,9 @@ final class HURLSessionDelegateTests: XCTestCase {
         XCTAssertNotNil(result.credential)
     }
 
-    func testSSLPinningWithWrongPinCancels() throws {
+    func testSSLPinningWithWrongPinCancels() async throws {
         // Given a server trust whose certificate does not match the configured pin
-        let serverTrust = try makeServerTrust()
+        let serverTrust = try await makeServerTrust()
         let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: [wrongPin])
 
         // When
@@ -109,9 +109,9 @@ final class HURLSessionDelegateTests: XCTestCase {
         XCTAssertNil(result.credential)
     }
 
-    func testMatchPinsCancelsForUntrustedChainEvenWithMatchingPin() throws {
+    func testMatchPinsCancelsForUntrustedChainEvenWithMatchingPin() async throws {
         // Given a server trust that does not evaluate as valid and a pin matching its certificate
-        let serverTrust = try makeUntrustedServerTrust()
+        let serverTrust = try await makeUntrustedServerTrust()
         let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: [testPin])
 
         // When
@@ -122,9 +122,9 @@ final class HURLSessionDelegateTests: XCTestCase {
         XCTAssertNil(result.credential)
     }
 
-    func testAsyncPinningEvaluationAnswersWithCredentialForValidPin() throws {
+    func testAsyncPinningEvaluationAnswersWithCredentialForValidPin() async throws {
         // Given a trusted server trust whose certificate matches the configured pin
-        let serverTrust = try makeServerTrust()
+        let serverTrust = try await makeServerTrust()
         let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: [testPin])
 
         let expectation = XCTestExpectation(description: "Async pinning evaluation answers the challenge")
@@ -137,12 +137,12 @@ final class HURLSessionDelegateTests: XCTestCase {
             expectation.fulfill()
         }
 
-        wait(for: [expectation], timeout: 2.0)
+        await fulfillment(of: [expectation], timeout: 2.0)
     }
 
-    func testAsyncPinningEvaluationCancelsForUntrustedChain() throws {
+    func testAsyncPinningEvaluationCancelsForUntrustedChain() async throws {
         // Given a server trust that does not evaluate as valid and a pin matching its certificate
-        let serverTrust = try makeUntrustedServerTrust()
+        let serverTrust = try await makeUntrustedServerTrust()
         let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: [testPin])
 
         let expectation = XCTestExpectation(description: "Async pinning evaluation cancels the challenge")
@@ -155,7 +155,7 @@ final class HURLSessionDelegateTests: XCTestCase {
             expectation.fulfill()
         }
 
-        wait(for: [expectation], timeout: 2.0)
+        await fulfillment(of: [expectation], timeout: 2.0)
     }
 
     // MARK: - Per-Host SSL Pinning Tests
@@ -300,19 +300,19 @@ final class HURLSessionDelegateTests: XCTestCase {
                                           sender: MockURLSessionSender())
     }
 
-    private func loadTestIdentity() throws -> HMTLSIdentity {
+    private func loadTestIdentity() async throws -> HMTLSIdentity {
         let p12URL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .appendingPathComponent("certificate.p12")
         let mTLS = HMTLS(p12FileUrl: p12URL, passwordProvider: { "notapassword" })
-        return try mTLS.extractIdentity()
+        return try await mTLS.extractIdentity()
     }
 
     /// Builds a synthetic SecTrust from the test certificate with the certificate installed
     /// as an anchor, so trust evaluation succeeds for the self-signed certificate.
-    private func makeServerTrust() throws -> SecTrust {
-        let serverTrust = try makeUntrustedServerTrust()
-        let identity = try loadTestIdentity()
+    private func makeServerTrust() async throws -> SecTrust {
+        let serverTrust = try await makeUntrustedServerTrust()
+        let identity = try await loadTestIdentity()
         let certificate = try XCTUnwrap(identity.certificateChain?.first)
         SecTrustSetAnchorCertificates(serverTrust, [certificate] as CFArray)
         SecTrustSetAnchorCertificatesOnly(serverTrust, false)
@@ -321,8 +321,8 @@ final class HURLSessionDelegateTests: XCTestCase {
 
     /// Builds a synthetic SecTrust from the test certificate. The trust is not anchored,
     /// so evaluating it fails on the self-signed certificate.
-    private func makeUntrustedServerTrust() throws -> SecTrust {
-        let identity = try loadTestIdentity()
+    private func makeUntrustedServerTrust() async throws -> SecTrust {
+        let identity = try await loadTestIdentity()
         let certificate = try XCTUnwrap(identity.certificateChain?.first)
         var serverTrust: SecTrust?
         let status = SecTrustCreateWithCertificates(certificate, SecPolicyCreateBasicX509(), &serverTrust)

--- a/Tests/HarborTests/HURLSessionDelegateTests.swift
+++ b/Tests/HarborTests/HURLSessionDelegateTests.swift
@@ -109,6 +109,19 @@ final class HURLSessionDelegateTests: XCTestCase {
         XCTAssertNil(result.credential)
     }
 
+    func testMatchPinsCancelsForUntrustedChainEvenWithMatchingPin() throws {
+        // Given a server trust that does not evaluate as valid and a pin matching its certificate
+        let serverTrust = try makeUntrustedServerTrust()
+        let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: [testPin])
+
+        // When
+        let result = delegate.matchPins(serverTrust: serverTrust, sslPinningKeys: [testPin])
+
+        // Then pins are never matched against an untrusted chain
+        XCTAssertEqual(result.disposition, .cancelAuthenticationChallenge)
+        XCTAssertNil(result.credential)
+    }
+
     // MARK: - Per-Host SSL Pinning Tests
 
     func testSSLPinningIsEnforcedForConfiguredHost() throws {
@@ -163,6 +176,78 @@ final class HURLSessionDelegateTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    // MARK: - Host Normalization Tests
+
+    func testNormalizedHostLowercasesAndStripsTrailingRootDot() {
+        XCTAssertEqual(HURLSessionDelegate.normalizedHost("API.Example.COM"), "api.example.com")
+        XCTAssertEqual(HURLSessionDelegate.normalizedHost("api.example.com."), "api.example.com")
+        XCTAssertEqual(HURLSessionDelegate.normalizedHost("api.example.com"), "api.example.com")
+    }
+
+    func testSSLPinningIsEnforcedForHostWithDifferentCase() throws {
+        // Given pins stored for a lowercase host and a challenge using a different case;
+        // DNS names are case-insensitive, so pinning must still apply
+        let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: nil, sslPinningKeysByHost: ["secure.example.com": [testPin]])
+        let challenge = makeChallenge(host: "SECURE.Example.COM", authenticationMethod: NSURLAuthenticationMethodServerTrust)
+
+        let expectation = XCTestExpectation(description: "Pinning enforced for differently-cased host")
+
+        // When
+        delegate.urlSession(URLSession.shared, didReceive: challenge) { disposition, _ in
+            // Then pinning applies: without a serverTrust the challenge is cancelled, not passed through
+            XCTAssertEqual(disposition, .cancelAuthenticationChallenge)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testSSLPinningIsEnforcedForHostWithTrailingRootDot() throws {
+        // Given pins stored for a host without a root-label dot and a challenge carrying it
+        let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: nil, sslPinningKeysByHost: ["secure.example.com": [testPin]])
+        let challenge = makeChallenge(host: "secure.example.com.", authenticationMethod: NSURLAuthenticationMethodServerTrust)
+
+        let expectation = XCTestExpectation(description: "Pinning enforced for host with trailing dot")
+
+        // When
+        delegate.urlSession(URLSession.shared, didReceive: challenge) { disposition, _ in
+            // Then pinning applies: without a serverTrust the challenge is cancelled, not passed through
+            XCTAssertEqual(disposition, .cancelAuthenticationChallenge)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    @HRequestManagerActor
+    func testSetSSLPinningKeysForHostsStoresNormalizedKeys() async {
+        // Given pins registered for a mixed-case host with a trailing root-label dot
+        Harbor.setSSLPinningKeys([testPin], forHosts: ["STORED.Example.COM."])
+
+        // Then the stored key is normalized
+        let stored = HConfig.shared.sslPinningKeysByHost
+        XCTAssertEqual(stored?["stored.example.com"], [testPin])
+        XCTAssertNil(stored?["STORED.Example.COM."])
+
+        // Cleanup with a differently-cased spelling also removes the entry
+        Harbor.setSSLPinningKeys(nil, forHosts: ["stored.example.com."])
+        let afterRemoval = HConfig.shared.sslPinningKeysByHost
+        XCTAssertNil(afterRemoval?["stored.example.com"])
+    }
+
+    @HRequestManagerActor
+    func testSetSSLPinningKeysForHostsSkipsEmptyKeys() async {
+        // Given an empty host key
+        Harbor.setSSLPinningKeys([testPin], forHosts: ["   "])
+
+        // Then nothing is stored for it
+        let stored = HConfig.shared.sslPinningKeysByHost
+        XCTAssertTrue(stored?.isEmpty ?? true)
+
+        // Cleanup
+        Harbor.setSSLPinningKeys(nil, forHosts: ["   "])
+    }
+
     // MARK: - Helpers
 
     private func makeChallenge(host: String, authenticationMethod: String) -> URLAuthenticationChallenge {
@@ -187,9 +272,20 @@ final class HURLSessionDelegateTests: XCTestCase {
         return try mTLS.extractIdentity()
     }
 
-    /// Builds a synthetic SecTrust from the test certificate. The trust is not evaluated
-    /// here; pin matching only needs the certificate chain.
+    /// Builds a synthetic SecTrust from the test certificate with the certificate installed
+    /// as an anchor, so trust evaluation succeeds for the self-signed certificate.
     private func makeServerTrust() throws -> SecTrust {
+        let serverTrust = try makeUntrustedServerTrust()
+        let identity = try loadTestIdentity()
+        let certificate = try XCTUnwrap(identity.certificateChain?.first)
+        SecTrustSetAnchorCertificates(serverTrust, [certificate] as CFArray)
+        SecTrustSetAnchorCertificatesOnly(serverTrust, false)
+        return serverTrust
+    }
+
+    /// Builds a synthetic SecTrust from the test certificate. The trust is not anchored,
+    /// so evaluating it fails on the self-signed certificate.
+    private func makeUntrustedServerTrust() throws -> SecTrust {
         let identity = try loadTestIdentity()
         let certificate = try XCTUnwrap(identity.certificateChain?.first)
         var serverTrust: SecTrust?

--- a/Tests/HarborTests/HURLSessionDelegateTests.swift
+++ b/Tests/HarborTests/HURLSessionDelegateTests.swift
@@ -10,27 +10,23 @@ import XCTest
 
 final class HURLSessionDelegateTests: XCTestCase {
 
+    // The pin of Tests/HarborTests/certificate.p12's leaf certificate, matching
+    // HarborSecurityTests.testSPKIPinMatchesOpenSSLOutput.
+    private let testPin = "X39uJq4Gmf5YvT9e7Q/Cc1DMepSL8aYi7hBI5l6qgO4="
+    // A syntactically valid pin (base64 of 32 zero bytes) that matches nothing.
+    private let wrongPin = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+    // MARK: - mTLS Challenge Tests
+
     func testDelegateHandlesMissingIdentity() {
         // Given
         // Initialize delegate with nil identity
         let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: nil)
-        
-        // Create a mock challenge for Client Certificate
-        let protectionSpace = URLProtectionSpace(host: "example.com",
-                                                 port: 443,
-                                                 protocol: "https",
-                                                 realm: nil,
-                                                 authenticationMethod: NSURLAuthenticationMethodClientCertificate)
-        
-        let challenge = URLAuthenticationChallenge(protectionSpace: protectionSpace,
-                                                   proposedCredential: nil,
-                                                   previousFailureCount: 0,
-                                                   failureResponse: nil,
-                                                   error: nil,
-                                                   sender: MockURLSessionSender())
-        
+
+        let challenge = makeChallenge(host: "example.com", authenticationMethod: NSURLAuthenticationMethodClientCertificate)
+
         let expectation = XCTestExpectation(description: "Challenge with nil identity")
-        
+
         // When
         delegate.urlSession(URLSession.shared, didReceive: challenge) { disposition, credential in
             // Then
@@ -39,34 +35,19 @@ final class HURLSessionDelegateTests: XCTestCase {
             XCTAssertNil(credential)
             expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: 1.0)
     }
 
     func testMTLSChallengeSendsCertificateChain() throws {
         // Given
-        let p12URL = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .appendingPathComponent("certificate.p12")
-        let mTLS = HmTLS(p12FileUrl: p12URL, password: "notapassword")
-        let identity = try mTLS.extractIdentity()
+        let identity = try loadTestIdentity()
         let expectedChainCount = try XCTUnwrap(identity.certificateChain, "Identity should include the certificate chain").count
         XCTAssertGreaterThan(expectedChainCount, 0)
 
         let delegate = HURLSessionDelegate(mTLSIdentity: identity, sslPinningKeys: nil)
 
-        let protectionSpace = URLProtectionSpace(host: "example.com",
-                                                 port: 443,
-                                                 protocol: "https",
-                                                 realm: nil,
-                                                 authenticationMethod: NSURLAuthenticationMethodClientCertificate)
-
-        let challenge = URLAuthenticationChallenge(protectionSpace: protectionSpace,
-                                                   proposedCredential: nil,
-                                                   previousFailureCount: 0,
-                                                   failureResponse: nil,
-                                                   error: nil,
-                                                   sender: MockURLSessionSender())
+        let challenge = makeChallenge(host: "example.com", authenticationMethod: NSURLAuthenticationMethodClientCertificate)
 
         let expectation = XCTestExpectation(description: "Challenge with identity and chain")
 
@@ -81,54 +62,142 @@ final class HURLSessionDelegateTests: XCTestCase {
 
         wait(for: [expectation], timeout: 1.0)
     }
-    
-    // MARK: - SSL Pinning Tests
-    
-    func testSSLPinningWithMultipleKeys_OneMatch_ShouldSucceed() {
-        // Since we can't easily mock SecTrust without real certs, we will at least verify that 
-        // initializing with multiple keys works and setting up the delegate works.
-        // NOTE: True logic validation requires a mocked TrustEvaluator which is not present in the current implementation.
-        // This test ensures no crashes occur during init and basic handling.
-        
-        // Given
-        let validKey1 = "VALID_KEY_1"
-        let validKey2 = "VALID_KEY_2"
-        let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: [validKey1, validKey2])
-        
-        let protectionSpace = URLProtectionSpace(host: "secure.example.com",
-                                                 port: 443,
-                                                 protocol: "https",
-                                                 realm: nil,
-                                                 authenticationMethod: NSURLAuthenticationMethodServerTrust)
-        
-        // Create a challenge without a serverTrust object (it will be nil)
-        // This should fail gracefully
-        let challenge = URLAuthenticationChallenge(protectionSpace: protectionSpace,
-                                                   proposedCredential: nil,
-                                                   previousFailureCount: 0,
-                                                   failureResponse: nil,
-                                                   error: nil,
-                                                   sender: MockURLSessionSender())
-        
+
+    // MARK: - SSL Pinning Challenge Tests
+
+    func testSSLPinningWithNilTrustCancels() {
+        // Given a delegate with pinning keys and a challenge without a serverTrust object
+        let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: [testPin])
+        let challenge = makeChallenge(host: "secure.example.com", authenticationMethod: NSURLAuthenticationMethodServerTrust)
+
         let expectation = XCTestExpectation(description: "SSL Pinning with nil trust")
-        
+
         // When
-        delegate.urlSession(URLSession.shared, didReceive: challenge) { disposition, credential in
+        delegate.urlSession(URLSession.shared, didReceive: challenge) { disposition, _ in
             // Then
             // Should cancel because serverTrust is nil
-            XCTAssertEqual(disposition, .cancelAuthenticationChallenge) // Or performDefaultHandling if it falls through, but based on code:
-            // guard ... let serverTrust ... else { return nil } -> returns completionHandler(.performDefaultHandling, nil) (Wait, check code)
-            
-            // Checking code:
-            // if let sslPinningKeys, let result = processSSLPinning(...) { ... }
-            // processSSLPinning returns nil if serverTrust is missing.
-            // If result is nil, it goes to: if sslPinningKeys != nil { return .cancel }
-            
             XCTAssertEqual(disposition, .cancelAuthenticationChallenge)
             expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testSSLPinningWithMatchingPinUsesCredential() throws {
+        // Given a server trust whose leaf certificate matches the configured pin
+        let serverTrust = try makeServerTrust()
+        let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: [testPin])
+
+        // When
+        let result = delegate.matchPins(serverTrust: serverTrust, sslPinningKeys: [testPin])
+
+        // Then
+        XCTAssertEqual(result.disposition, .useCredential)
+        XCTAssertNotNil(result.credential)
+    }
+
+    func testSSLPinningWithWrongPinCancels() throws {
+        // Given a server trust whose certificate does not match the configured pin
+        let serverTrust = try makeServerTrust()
+        let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: [wrongPin])
+
+        // When
+        let result = delegate.matchPins(serverTrust: serverTrust, sslPinningKeys: [wrongPin])
+
+        // Then
+        XCTAssertEqual(result.disposition, .cancelAuthenticationChallenge)
+        XCTAssertNil(result.credential)
+    }
+
+    // MARK: - Per-Host SSL Pinning Tests
+
+    func testSSLPinningIsEnforcedForConfiguredHost() throws {
+        // Given pins scoped to a specific host and a challenge from that host
+        let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: nil, sslPinningKeysByHost: ["secure.example.com": [testPin]])
+        let challenge = makeChallenge(host: "secure.example.com", authenticationMethod: NSURLAuthenticationMethodServerTrust)
+
+        let expectation = XCTestExpectation(description: "Pinning enforced for configured host")
+
+        // When
+        delegate.urlSession(URLSession.shared, didReceive: challenge) { disposition, _ in
+            // Then pinning applies: without a serverTrust the challenge is cancelled, not passed through
+            XCTAssertEqual(disposition, .cancelAuthenticationChallenge)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testSSLPinningPassesThroughForUnconfiguredHost() throws {
+        // Given pins scoped to a specific host and a challenge from a different host
+        let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: nil, sslPinningKeysByHost: ["secure.example.com": [testPin]])
+        let challenge = makeChallenge(host: "other.example.com", authenticationMethod: NSURLAuthenticationMethodServerTrust)
+
+        let expectation = XCTestExpectation(description: "Default handling for unconfigured host")
+
+        // When
+        delegate.urlSession(URLSession.shared, didReceive: challenge) { disposition, credential in
+            // Then the host is not pinned and gets default handling
+            XCTAssertEqual(disposition, .performDefaultHandling)
+            XCTAssertNil(credential)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testSSLPinningGlobalKeysStillApplyToEveryHost() throws {
+        // Given global pins and scoped pins, a challenge from an unscoped host uses the global ones
+        let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: [testPin], sslPinningKeysByHost: ["secure.example.com": [testPin]])
+        let challenge = makeChallenge(host: "other.example.com", authenticationMethod: NSURLAuthenticationMethodServerTrust)
+
+        let expectation = XCTestExpectation(description: "Global pins apply to unscoped host")
+
+        // When
+        delegate.urlSession(URLSession.shared, didReceive: challenge) { disposition, _ in
+            // Then the global pins apply, so the missing serverTrust cancels the challenge
+            XCTAssertEqual(disposition, .cancelAuthenticationChallenge)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    // MARK: - Helpers
+
+    private func makeChallenge(host: String, authenticationMethod: String) -> URLAuthenticationChallenge {
+        let protectionSpace = URLProtectionSpace(host: host,
+                                                 port: 443,
+                                                 protocol: "https",
+                                                 realm: nil,
+                                                 authenticationMethod: authenticationMethod)
+        return URLAuthenticationChallenge(protectionSpace: protectionSpace,
+                                          proposedCredential: nil,
+                                          previousFailureCount: 0,
+                                          failureResponse: nil,
+                                          error: nil,
+                                          sender: MockURLSessionSender())
+    }
+
+    private func loadTestIdentity() throws -> HMTLSIdentity {
+        let p12URL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("certificate.p12")
+        let mTLS = HMTLS(p12FileUrl: p12URL, passwordProvider: { "notapassword" })
+        return try mTLS.extractIdentity()
+    }
+
+    /// Builds a synthetic SecTrust from the test certificate. The trust is not evaluated
+    /// here; pin matching only needs the certificate chain.
+    private func makeServerTrust() throws -> SecTrust {
+        let identity = try loadTestIdentity()
+        let certificate = try XCTUnwrap(identity.certificateChain?.first)
+        var serverTrust: SecTrust?
+        let status = SecTrustCreateWithCertificates(certificate, SecPolicyCreateBasicX509(), &serverTrust)
+        guard status == errSecSuccess, let serverTrust else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(status))
+        }
+        return serverTrust
     }
 }
 

--- a/Tests/HarborTests/HURLSessionDelegateTests.swift
+++ b/Tests/HarborTests/HURLSessionDelegateTests.swift
@@ -122,6 +122,42 @@ final class HURLSessionDelegateTests: XCTestCase {
         XCTAssertNil(result.credential)
     }
 
+    func testAsyncPinningEvaluationAnswersWithCredentialForValidPin() throws {
+        // Given a trusted server trust whose certificate matches the configured pin
+        let serverTrust = try makeServerTrust()
+        let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: [testPin])
+
+        let expectation = XCTestExpectation(description: "Async pinning evaluation answers the challenge")
+
+        // When the pinning flow evaluates the trust and answers through the completion handler
+        delegate.evaluateAndMatchPins(serverTrust: serverTrust, sslPinningKeys: [testPin]) { disposition, credential in
+            // Then the matching pin uses the credential
+            XCTAssertEqual(disposition, .useCredential)
+            XCTAssertNotNil(credential)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func testAsyncPinningEvaluationCancelsForUntrustedChain() throws {
+        // Given a server trust that does not evaluate as valid and a pin matching its certificate
+        let serverTrust = try makeUntrustedServerTrust()
+        let delegate = HURLSessionDelegate(mTLSIdentity: nil, sslPinningKeys: [testPin])
+
+        let expectation = XCTestExpectation(description: "Async pinning evaluation cancels the challenge")
+
+        // When
+        delegate.evaluateAndMatchPins(serverTrust: serverTrust, sslPinningKeys: [testPin]) { disposition, credential in
+            // Then the challenge is cancelled without matching pins against the untrusted chain
+            XCTAssertEqual(disposition, .cancelAuthenticationChallenge)
+            XCTAssertNil(credential)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
     // MARK: - Per-Host SSL Pinning Tests
 
     func testSSLPinningIsEnforcedForConfiguredHost() throws {

--- a/Tests/HarborTests/HarborCacheTests.swift
+++ b/Tests/HarborTests/HarborCacheTests.swift
@@ -653,7 +653,7 @@ final class HarborCacheTests: XCTestCase {
         await HCache.Manager.shared.waitForPendingDiskOperations()
 
         let fileURL = HCache.Manager.shared.cacheDirectory
-            .appendingPathComponent(key.sha256Hash)
+            .appendingPathComponent(key.sha256Hex)
             .appendingPathExtension("cache")
         XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path), "Data of exactly maxObjectSizeInBytes should be cached")
     }
@@ -835,7 +835,7 @@ final class HarborCacheTests: XCTestCase {
         await HCache.Manager.shared.waitForPendingDiskOperations()
 
         let fileURL = HCache.Manager.shared.cacheDirectory
-            .appendingPathComponent(key.sha256Hash)
+            .appendingPathComponent(key.sha256Hex)
             .appendingPathExtension("cache")
         XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path), "Entry should be persisted on disk")
 

--- a/Tests/HarborTests/HarborConfigurationTests.swift
+++ b/Tests/HarborTests/HarborConfigurationTests.swift
@@ -15,7 +15,7 @@ final class HarborConfigurationTests: XCTestCase {
         await Harbor.setDefaultHeaderParameters(nil)
         await Harbor.setAuthProvider(nil)
         await Harbor.setCustomURLSession(URLSession.shared)
-        await Harbor.setSSlPinningKeys(nil)
+        await Harbor.setSSLPinningKeys(nil)
         await Harbor.clearMTLS()
         await Harbor.setMocksOnlyInDebug(true)
         await Harbor.removeAllMocks()
@@ -26,7 +26,7 @@ final class HarborConfigurationTests: XCTestCase {
         await Harbor.setDefaultHeaderParameters(nil)
         await Harbor.setAuthProvider(nil)
         await Harbor.setCustomURLSession(URLSession.shared)
-        await Harbor.setSSlPinningKeys(nil)
+        await Harbor.setSSLPinningKeys(nil)
         await Harbor.clearMTLS()
         await Harbor.setMocksOnlyInDebug(true)
         await Harbor.removeAllMocks()
@@ -319,7 +319,7 @@ private struct TestConfigData: HModel {
 // MARK: - Test Auth Provider
 
 private final class TestAuthProvider: HAuthProviderProtocol, @unchecked Sendable {
-    func getAuthorizationHeader() async -> HAuthorizationHeader {
+    func getAuthorizationHeader() async -> HAuthorizationHeader? {
         return HAuthorizationHeader(key: "Authorization", value: "Bearer test-token")
     }
     

--- a/Tests/HarborTests/HarborDiskCacheTests.swift
+++ b/Tests/HarborTests/HarborDiskCacheTests.swift
@@ -36,7 +36,7 @@ final class HarborDiskCacheTests: XCTestCase {
         await HCache.Manager.shared.waitForPendingDiskOperations()
 
         // 3. Verify File Exists
-        let hash = key.sha256Hash
+        let hash = key.sha256Hex
         let cacheDir = HCache.Manager.shared.cacheDirectory
 
         // New format: .cache extension
@@ -61,7 +61,7 @@ final class HarborDiskCacheTests: XCTestCase {
 
         // 1. Manually write file to disk (simulating previous session) - use URL directly as key
         let key = request.url
-        let hash = key.sha256Hash
+        let hash = key.sha256Hex
         let cacheDir = HCache.Manager.shared.cacheDirectory
         let fileURL = cacheDir.appendingPathComponent(hash).appendingPathExtension("cache")
 
@@ -83,7 +83,7 @@ final class HarborDiskCacheTests: XCTestCase {
         let config = HCache.Configuration()
 
         let key = request.url
-        let hash = key.sha256Hash
+        let hash = key.sha256Hex
         let cacheDir = HCache.Manager.shared.cacheDirectory
         let fileURL = cacheDir.appendingPathComponent(hash).appendingPathExtension("cache")
 
@@ -109,7 +109,7 @@ final class HarborDiskCacheTests: XCTestCase {
         await HCache.Manager.shared.waitForPendingDiskOperations()
 
         // 3. Verify NOT in disk
-        let hash = key.sha256Hash
+        let hash = key.sha256Hex
         let fileURL = HCache.Manager.shared.cacheDirectory.appendingPathComponent(hash).appendingPathExtension("cache")
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path), "Should not persist files larger than limit")
@@ -127,7 +127,7 @@ final class HarborDiskCacheTests: XCTestCase {
         await HCache.Manager.shared.waitForPendingDiskOperations()
 
         // 3. Verify IS in disk
-        let hash = key.sha256Hash
+        let hash = key.sha256Hex
         let fileURL = HCache.Manager.shared.cacheDirectory.appendingPathComponent(hash).appendingPathExtension("cache")
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path), "Should persist files smaller than custom limit")
@@ -154,7 +154,7 @@ final class HarborDiskCacheTests: XCTestCase {
 
         // Pin deterministic modification dates instead of relying on write-order mtimes
         let cacheDir = HCache.Manager.shared.cacheDirectory
-        let fileURLs = keys.map { cacheDir.appendingPathComponent($0.sha256Hash).appendingPathExtension("cache") }
+        let fileURLs = keys.map { cacheDir.appendingPathComponent($0.sha256Hex).appendingPathExtension("cache") }
         let sentinelDates = [
             Date().addingTimeInterval(-3600),
             Date().addingTimeInterval(-1800),
@@ -169,7 +169,7 @@ final class HarborDiskCacheTests: XCTestCase {
         await HCache.Manager.shared.storeData(entryData, forKey: extraKey, config: config, response: nil)
         await HCache.Manager.shared.waitForPendingDiskOperations()
 
-        let extraURL = cacheDir.appendingPathComponent(extraKey.sha256Hash).appendingPathExtension("cache")
+        let extraURL = cacheDir.appendingPathComponent(extraKey.sha256Hex).appendingPathExtension("cache")
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: fileURLs[0].path), "Oldest entry should be evicted to fit the disk capacity")
         XCTAssertTrue(FileManager.default.fileExists(atPath: fileURLs[1].path), "Middle entry should be kept")
@@ -206,7 +206,7 @@ final class HarborDiskCacheTests: XCTestCase {
 
     func testLegacyFilesAreRemovedOnStore() async throws {
         let key = "https://disk.test/legacy"
-        let hash = key.sha256Hash
+        let hash = key.sha256Hex
         let cacheDir = HCache.Manager.shared.cacheDirectory
 
         // Legacy format: data file without extension plus a .meta sidecar

--- a/Tests/HarborTests/HarborRequestManagerAuthTests.swift
+++ b/Tests/HarborTests/HarborRequestManagerAuthTests.swift
@@ -499,4 +499,72 @@ final class HarborRequestManagerAuthTests: XCTestCase {
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: ["Vary": "Authorization"])
         await request.saveCache(data, response: response, authHeader: authHeader)
     }
+
+    // MARK: - Offline Stale Cache Tests
+
+    func testOfflineStaleCacheHitDoesNotConsultTheAuthProvider() async throws {
+        // Given an offline monitor, a stale servable entry without Vary, and a provider
+        // configured only after storing (so the store itself cannot consult it)
+        HRequestManager.connectivityMonitor = FakeConnectivityMonitor(connected: false)
+        defer { HRequestManager.connectivityMonitor = HRequestManagerMonitor() }
+        await Harbor.clearAllCache()
+        Harbor.setDefaultCacheType(.custom(HCache.Configuration(expirationTime: .oneHour)))
+        Harbor.setAuthProvider(nil)
+
+        let request = ClassAuthGetRequest(url: "https://example.com/offline-stale")
+        try await storeStaleEntry(Data("{\"quote\":\"stale\"}".utf8), for: request, headers: ["Cache-Control": "max-age=0, stale-if-error=300"])
+
+        let provider = SpyAuthProvider(headers: [HAuthorizationHeader(key: "Authorization", value: "Bearer token_A")])
+        Harbor.setAuthProvider(provider)
+
+        // When
+        let response = await request.request()
+
+        // Then the stale body is served without consulting the provider
+        guard case .success(let model) = response else {
+            XCTFail("Expected the stale body but got: \(response)")
+            return
+        }
+        XCTAssertEqual(model.quote, "stale")
+        XCTAssertEqual(provider.headerCallCount, 0)
+    }
+
+    func testOfflineStaleCacheMissResolvesAuthHeaderAndRetriesLookup() async throws {
+        // Given an offline monitor and a stale servable Vary: Authorization entry stored
+        // under a credential
+        HRequestManager.connectivityMonitor = FakeConnectivityMonitor(connected: false)
+        defer { HRequestManager.connectivityMonitor = HRequestManagerMonitor() }
+        await Harbor.clearAllCache()
+        Harbor.setDefaultCacheType(.custom(HCache.Configuration(expirationTime: .oneHour)))
+        Harbor.setAuthProvider(nil)
+
+        let token = HAuthorizationHeader(key: "Authorization", value: "Bearer token_A")
+        let request = ClassAuthGetRequest(url: "https://example.com/offline-stale-vary")
+        try await storeStaleEntry(Data("{\"quote\":\"stale-vary\"}".utf8),
+                                  for: request,
+                                  headers: ["Cache-Control": "max-age=0, stale-if-error=300", "Vary": "Authorization"],
+                                  authHeader: token)
+
+        let provider = SpyAuthProvider(headers: [token])
+        Harbor.setAuthProvider(provider)
+
+        // When: the first lookup misses (no credential), so the header is resolved once
+        // and the second lookup hits
+        let response = await request.request()
+
+        // Then
+        guard case .success(let model) = response else {
+            XCTFail("Expected the stale body but got: \(response)")
+            return
+        }
+        XCTAssertEqual(model.quote, "stale-vary")
+        XCTAssertEqual(provider.headerCallCount, 1)
+    }
+
+    /// Stores a body as an immediately expired, stale servable cache entry for the given request.
+    private func storeStaleEntry(_ data: Data, for request: ClassAuthGetRequest, headers: [String: String], authHeader: HAuthorizationHeader? = nil) async throws {
+        let url = try XCTUnwrap(URL(string: request.url))
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: headers)
+        await request.saveCache(data, response: response, authHeader: authHeader)
+    }
 }

--- a/Tests/HarborTests/HarborRequestManagerAuthTests.swift
+++ b/Tests/HarborTests/HarborRequestManagerAuthTests.swift
@@ -445,4 +445,58 @@ final class HarborRequestManagerAuthTests: XCTestCase {
         XCTAssertEqual(modelBAgain.quote, "Bearer token_B")
         XCTAssertEqual(AuthStubProtocol.receivedIfNoneMatch, [nil, nil, "\"vary-etag\""])
     }
+
+    func testCacheReadWithoutExplicitHeaderResolvesItFromTheProvider() async throws {
+        // Given a stored Vary: Authorization entry and a provider issuing the same credential
+        await Harbor.clearAllCache()
+        Harbor.setDefaultCacheType(.custom(HCache.Configuration(expirationTime: .oneHour)))
+        let token = HAuthorizationHeader(key: "Authorization", value: "Bearer token_A")
+        Harbor.setAuthProvider(SpyAuthProvider(headers: [token]))
+
+        let request = ClassAuthGetRequest(url: "https://example.com/vary-auto")
+        try await storeVaryAuthorizationEntry(Data("{\"quote\":\"cached\"}".utf8), for: request, authHeader: token)
+
+        // When the cache is read without an explicit header, the provider's header keys
+        // the vary lookup and the entry is served
+        let cached = await request.cache()
+        XCTAssertEqual(cached?.quote, "cached")
+    }
+
+    func testCacheReadWithoutExplicitHeaderMissesWhenProviderCredentialDiffers() async throws {
+        // Given a stored Vary: Authorization entry and a provider issuing a different credential
+        await Harbor.clearAllCache()
+        Harbor.setDefaultCacheType(.custom(HCache.Configuration(expirationTime: .oneHour)))
+        let storedToken = HAuthorizationHeader(key: "Authorization", value: "Bearer token_A")
+        let otherToken = HAuthorizationHeader(key: "Authorization", value: "Bearer token_B")
+        Harbor.setAuthProvider(SpyAuthProvider(headers: [otherToken]))
+
+        let request = ClassAuthGetRequest(url: "https://example.com/vary-auto")
+        try await storeVaryAuthorizationEntry(Data("{\"quote\":\"cached\"}".utf8), for: request, authHeader: storedToken)
+
+        // When the cache is read, the vary mismatch must not serve the stored variant
+        let cached = await request.cache()
+        XCTAssertNil(cached)
+    }
+
+    func testCacheReadWithoutExplicitHeaderMissesGracefullyWithoutProvider() async throws {
+        // Given a stored Vary: Authorization entry and no configured provider
+        await Harbor.clearAllCache()
+        Harbor.setDefaultCacheType(.custom(HCache.Configuration(expirationTime: .oneHour)))
+        Harbor.setAuthProvider(nil)
+        let token = HAuthorizationHeader(key: "Authorization", value: "Bearer token_A")
+
+        let request = ClassAuthGetRequest(url: "https://example.com/vary-auto")
+        try await storeVaryAuthorizationEntry(Data("{\"quote\":\"cached\"}".utf8), for: request, authHeader: token)
+
+        // When the cache is read, the lookup proceeds without a header and misses
+        let cached = await request.cache()
+        XCTAssertNil(cached)
+    }
+
+    /// Stores a body as a `Vary: Authorization` cache entry for the given request.
+    private func storeVaryAuthorizationEntry(_ data: Data, for request: ClassAuthGetRequest, authHeader: HAuthorizationHeader) async throws {
+        let url = try XCTUnwrap(URL(string: request.url))
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: ["Vary": "Authorization"])
+        await request.saveCache(data, response: response, authHeader: authHeader)
+    }
 }

--- a/Tests/HarborTests/HarborRequestManagerAuthTests.swift
+++ b/Tests/HarborTests/HarborRequestManagerAuthTests.swift
@@ -43,16 +43,28 @@ private final class SpyAuthProvider: HAuthProviderProtocol {
 
 /// URLProtocol stub injected through `HConfig.protocolClasses`. It answers with a scripted
 /// sequence of status codes (repeating the last one) and records the Authorization header
-/// of every request it sees.
+/// of every request it sees. Optionally it sends response headers (e.g. `Vary`, `ETag`),
+/// answers `304 Not Modified` when the request's `If-None-Match` matches the configured
+/// ETag, and echoes the Authorization header in the body.
 private final class AuthStubProtocol: URLProtocol {
     private static let lock = NSLock()
     nonisolated(unsafe) private static var _statusCodes: [Int] = [200]
     nonisolated(unsafe) private static var _receivedAuthorizations: [String?] = []
+    nonisolated(unsafe) private static var _receivedIfNoneMatch: [String?] = []
+    nonisolated(unsafe) private static var _responseHeaders: [String: String]?
+    nonisolated(unsafe) private static var _etag: String?
+    nonisolated(unsafe) private static var _bodyIncludesAuthorization = false
 
     static var receivedAuthorizations: [String?] {
         lock.lock()
         defer { lock.unlock() }
         return _receivedAuthorizations
+    }
+
+    static var receivedIfNoneMatch: [String?] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _receivedIfNoneMatch
     }
 
     static var statusCodes: [Int] {
@@ -68,15 +80,59 @@ private final class AuthStubProtocol: URLProtocol {
         }
     }
 
+    static var responseHeaders: [String: String]? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _responseHeaders
+        }
+        set {
+            lock.lock()
+            _responseHeaders = newValue
+            lock.unlock()
+        }
+    }
+
+    static var etag: String? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _etag
+        }
+        set {
+            lock.lock()
+            _etag = newValue
+            lock.unlock()
+        }
+    }
+
+    static var bodyIncludesAuthorization: Bool {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _bodyIncludesAuthorization
+        }
+        set {
+            lock.lock()
+            _bodyIncludesAuthorization = newValue
+            lock.unlock()
+        }
+    }
+
     static func reset() {
         lock.lock()
         _statusCodes = [200]
         _receivedAuthorizations = []
+        _receivedIfNoneMatch = []
+        _responseHeaders = nil
+        _etag = nil
+        _bodyIncludesAuthorization = false
         lock.unlock()
     }
 
     override class func canInit(with request: URLRequest) -> Bool {
-        return true
+        // Only stub the hosts the tests target; anything else fails loudly.
+        return request.url?.host == "example.com"
     }
 
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {
@@ -86,18 +142,36 @@ private final class AuthStubProtocol: URLProtocol {
     override func startLoading() {
         Self.lock.lock()
         let index = Self._receivedAuthorizations.count
-        Self._receivedAuthorizations.append(request.value(forHTTPHeaderField: "Authorization"))
+        let authorization = request.value(forHTTPHeaderField: "Authorization")
+        let ifNoneMatch = request.value(forHTTPHeaderField: "If-None-Match")
+        Self._receivedAuthorizations.append(authorization)
+        Self._receivedIfNoneMatch.append(ifNoneMatch)
         let statusCodes = Self._statusCodes
+        let responseHeaders = Self._responseHeaders
+        let etag = Self._etag
+        let bodyIncludesAuthorization = Self._bodyIncludesAuthorization
         Self.lock.unlock()
 
-        let statusCode = statusCodes[min(index, statusCodes.count - 1)]
+        var statusCode = statusCodes[min(index, statusCodes.count - 1)]
+        if let etag, ifNoneMatch == etag {
+            statusCode = 304
+        }
+
+        var headerFields = responseHeaders ?? [:]
+        if let etag {
+            headerFields["ETag"] = etag
+        }
+
         guard let url = request.url,
-              let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil) else {
+              let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: headerFields) else {
             client?.urlProtocol(self, didFailWithError: URLError(.badURL))
             return
         }
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        client?.urlProtocol(self, didLoad: Data("{\"quote\":\"ok\"}".utf8))
+        if statusCode != 304 {
+            let quote = bodyIncludesAuthorization ? (authorization ?? "none") : "ok"
+            client?.urlProtocol(self, didLoad: Data("{\"quote\":\"\(quote)\"}".utf8))
+        }
         client?.urlProtocolDidFinishLoading(self)
     }
 
@@ -158,6 +232,8 @@ final class HarborRequestManagerAuthTests: XCTestCase {
         Harbor.setAuthProvider(nil)
         HConfig.shared.customURLSession = nil
         Harbor.setProtocolClasses(nil)
+        Harbor.setDefaultCacheType(.urlCache())
+        await Harbor.clearAllCache()
         AuthStubProtocol.reset()
     }
 
@@ -303,5 +379,70 @@ final class HarborRequestManagerAuthTests: XCTestCase {
             return
         }
         XCTAssertEqual(AuthStubProtocol.receivedAuthorizations, [nil])
+    }
+
+    func test401OnRequestThatOptedOutOfAuthGivesUpWithoutConsultingTheProvider() async throws {
+        // Given a provider with credentials and a request that does not need auth, answered with a 401
+        let provider = SpyAuthProvider(headers: [HAuthorizationHeader(key: "Authorization", value: "Bearer token_1")])
+        Harbor.setAuthProvider(provider)
+        AuthStubProtocol.statusCodes = [401]
+
+        let request = ClassAuthGetRequest(url: "https://example.com/public", needsAuth: false)
+
+        // When
+        let response = await request.request()
+
+        // Then the flow gives up with .authNeeded and the provider is never consulted
+        guard case .error(let error) = response, case .authNeeded = error else {
+            XCTFail("Expected .authNeeded but got: \(response)")
+            return
+        }
+        XCTAssertEqual(provider.headerCallCount, 0)
+        XCTAssertEqual(provider.authFailedCount, 0)
+        XCTAssertEqual(AuthStubProtocol.receivedAuthorizations, [nil])
+    }
+
+    // MARK: - Vary: Authorization Cache Tests
+
+    func testVaryAuthorizationVariantsAreKeyedPerCredential() async throws {
+        // Given a custom cache and a server that varies on Authorization, tagging each
+        // body with the credential it was fetched with
+        await Harbor.clearAllCache()
+        Harbor.setDefaultCacheType(.custom(HCache.Configuration(expirationTime: .oneHour)))
+        AuthStubProtocol.responseHeaders = ["Vary": "Authorization"]
+        AuthStubProtocol.etag = "\"vary-etag\""
+        AuthStubProtocol.bodyIncludesAuthorization = true
+
+        let tokenA = HAuthorizationHeader(key: "Authorization", value: "Bearer token_A")
+        let tokenB = HAuthorizationHeader(key: "Authorization", value: "Bearer token_B")
+
+        let request = ClassAuthGetRequest(url: "https://example.com/vary")
+
+        // When user A fetches, the response is cached under A's credential
+        Harbor.setAuthProvider(SpyAuthProvider(headers: [tokenA]))
+        guard case .success(let modelA) = await request.request() else {
+            XCTFail("Expected success for the first request")
+            return
+        }
+        XCTAssertEqual(modelA.quote, "Bearer token_A")
+
+        // Then a request with B's credential must not be served A's cached variant: the
+        // vary mismatch withholds the validators, so the server answers a full 200
+        Harbor.setAuthProvider(SpyAuthProvider(headers: [tokenB]))
+        guard case .success(let modelB) = await request.request() else {
+            XCTFail("Expected success for the second request")
+            return
+        }
+        XCTAssertEqual(modelB.quote, "Bearer token_B")
+
+        // And repeating B's credential revalidates: the server answers 304 and the
+        // cached variant for B is served
+        Harbor.setAuthProvider(SpyAuthProvider(headers: [tokenB]))
+        guard case .success(let modelBAgain) = await request.request() else {
+            XCTFail("Expected success for the revalidation request")
+            return
+        }
+        XCTAssertEqual(modelBAgain.quote, "Bearer token_B")
+        XCTAssertEqual(AuthStubProtocol.receivedIfNoneMatch, [nil, nil, "\"vary-etag\""])
     }
 }

--- a/Tests/HarborTests/HarborRequestManagerAuthTests.swift
+++ b/Tests/HarborTests/HarborRequestManagerAuthTests.swift
@@ -9,12 +9,113 @@ import XCTest
 @testable import Harbor
 
 private final class MockAuthProvider: HAuthProviderProtocol {
-    func getAuthorizationHeader() async -> HAuthorizationHeader {
+    func getAuthorizationHeader() async -> HAuthorizationHeader? {
         return HAuthorizationHeader(key: "Authorization", value: "Bearer mock_token")
     }
 
     func authFailed() async {
         // Handle auth failure logic if needed.
+    }
+}
+
+/// Auth provider that returns a scripted sequence of headers and records its usage.
+/// A `nil` element means the provider has no credentials at that point.
+@HRequestManagerActor
+private final class SpyAuthProvider: HAuthProviderProtocol {
+    private(set) var headerCallCount = 0
+    private(set) var authFailedCount = 0
+    private var headers: [HAuthorizationHeader?]
+
+    init(headers: [HAuthorizationHeader?]) {
+        self.headers = headers
+    }
+
+    func getAuthorizationHeader() async -> HAuthorizationHeader? {
+        headerCallCount += 1
+        guard !headers.isEmpty else { return nil }
+        return headers.removeFirst()
+    }
+
+    func authFailed() async {
+        authFailedCount += 1
+    }
+}
+
+/// URLProtocol stub injected through `HConfig.protocolClasses`. It answers with a scripted
+/// sequence of status codes (repeating the last one) and records the Authorization header
+/// of every request it sees.
+private final class AuthStubProtocol: URLProtocol {
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var _statusCodes: [Int] = [200]
+    nonisolated(unsafe) private static var _receivedAuthorizations: [String?] = []
+
+    static var receivedAuthorizations: [String?] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _receivedAuthorizations
+    }
+
+    static var statusCodes: [Int] {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _statusCodes
+        }
+        set {
+            lock.lock()
+            _statusCodes = newValue
+            lock.unlock()
+        }
+    }
+
+    static func reset() {
+        lock.lock()
+        _statusCodes = [200]
+        _receivedAuthorizations = []
+        lock.unlock()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        Self.lock.lock()
+        let index = Self._receivedAuthorizations.count
+        Self._receivedAuthorizations.append(request.value(forHTTPHeaderField: "Authorization"))
+        let statusCodes = Self._statusCodes
+        Self.lock.unlock()
+
+        let statusCode = statusCodes[min(index, statusCodes.count - 1)]
+        guard let url = request.url,
+              let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("{\"quote\":\"ok\"}".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+/// Reference-type request conformer: the auth flow must never mutate the caller's instance.
+private final class ClassAuthGetRequest: HGetRequestProtocol, @unchecked Sendable {
+    typealias Model = MockModel
+
+    let url: String
+    var headerParameters: [String: String]?
+    let needsAuth: Bool
+
+    init(url: String, headerParameters: [String: String]? = nil, needsAuth: Bool = true) {
+        self.url = url
+        self.headerParameters = headerParameters
+        self.needsAuth = needsAuth
     }
 }
 
@@ -44,7 +145,25 @@ extension HRequestError: Equatable {
 @HRequestManagerActor
 final class HarborRequestManagerAuthTests: XCTestCase {
 
-    func testAddAuthCredentialsIfNeededWithAuthSuccess() async throws {
+    override func setUp() async throws {
+        Harbor.removeAllMocks()
+        Harbor.setAuthProvider(nil)
+        HConfig.shared.customURLSession = nil
+        Harbor.setProtocolClasses([AuthStubProtocol.self])
+        AuthStubProtocol.reset()
+    }
+
+    override func tearDown() async throws {
+        Harbor.removeAllMocks()
+        Harbor.setAuthProvider(nil)
+        HConfig.shared.customURLSession = nil
+        Harbor.setProtocolClasses(nil)
+        AuthStubProtocol.reset()
+    }
+
+    // MARK: - Authorization Header Resolution
+
+    func testAuthorizationHeaderIfNeededWithAuthSuccess() async throws {
         // Given
         let mockAuthProvider = MockAuthProvider()
         HConfig.shared.authProvider = mockAuthProvider
@@ -52,17 +171,17 @@ final class HarborRequestManagerAuthTests: XCTestCase {
         let mockRequest = MockGetRequest<String>(needsAuth: true, url: "https://example.com/mock_endpoint")
 
         // When
-        let result = await HRequestManager.addAuthCredentialsIfNeeded(mockRequest)
+        let result = await HRequestManager.authorizationHeaderIfNeeded(for: mockRequest)
 
         // Then
-        guard case .success(let modifiedRequest) = result else {
-            XCTFail("Expected modified request with auth credentials")
+        guard case .success(let authHeader) = result else {
+            XCTFail("Expected the provider's authorization header")
             return
         }
-        XCTAssertEqual(modifiedRequest.headerParameters?["Authorization"], "Bearer mock_token", "Expected authorization header to be set correctly")
+        XCTAssertEqual(authHeader, HAuthorizationHeader(key: "Authorization", value: "Bearer mock_token"))
     }
 
-    func testAddAuthCredentialsIfNeededWithoutAuth() async throws {
+    func testAuthorizationHeaderIfNeededWithoutAuth() async throws {
         // Given
         let mockAuthProvider = MockAuthProvider()
         HConfig.shared.authProvider = mockAuthProvider
@@ -70,29 +189,119 @@ final class HarborRequestManagerAuthTests: XCTestCase {
         let mockRequest = MockGetRequest<String>(needsAuth: false, url: "https://example.com/mock_endpoint")
 
         // When
-        let result = await HRequestManager.addAuthCredentialsIfNeeded(mockRequest)
+        let result = await HRequestManager.authorizationHeaderIfNeeded(for: mockRequest)
 
         // Then
-        guard case .success(let modifiedRequest) = result else {
-            XCTFail("Expected original request since auth is not needed")
+        guard case .success(let authHeader) = result else {
+            XCTFail("Expected success since auth is not needed")
             return
         }
-        XCTAssertNil(modifiedRequest.headerParameters?["Authorization"], "Expected no authorization header since auth is not needed")
+        XCTAssertNil(authHeader, "Expected no authorization header since auth is not needed")
     }
 
-    func testAddAuthCredentialsIfNeededWithoutProviderFails() async throws {
+    func testAuthorizationHeaderIfNeededWithoutProviderFails() async throws {
         // Given
         HConfig.shared.authProvider = nil
 
         let mockRequest = MockGetRequest<String>(needsAuth: true, url: "https://example.com/mock_endpoint")
 
         // When
-        let result = await HRequestManager.addAuthCredentialsIfNeeded(mockRequest)
+        let result = await HRequestManager.authorizationHeaderIfNeeded(for: mockRequest)
 
         // Then
         guard case .failure(let error) = result, case .authProviderNeeded = error else {
             XCTFail("Expected .authProviderNeeded but got: \(result)")
             return
         }
+    }
+
+    // MARK: - Auth Flow With Stubbed Network
+
+    func testAuthHeaderIsSentOnTheWireWithoutMutatingTheRequest() async throws {
+        // Given a class-conformed request and a provider with credentials
+        let provider = SpyAuthProvider(headers: [HAuthorizationHeader(key: "Authorization", value: "Bearer token_1")])
+        Harbor.setAuthProvider(provider)
+        AuthStubProtocol.statusCodes = [200]
+
+        let request = ClassAuthGetRequest(url: "https://example.com/secure", headerParameters: ["X-Custom": "value"])
+
+        // When
+        let response = await request.request()
+
+        // Then the request succeeds, the wire carried the provider's header, and the
+        // caller's request object was not mutated
+        guard case .success = response else {
+            XCTFail("Expected success but got: \(response)")
+            return
+        }
+        XCTAssertEqual(AuthStubProtocol.receivedAuthorizations, ["Bearer token_1"])
+        XCTAssertEqual(request.headerParameters, ["X-Custom": "value"])
+    }
+
+    func testAuthRetryWithFreshHeaderDoesNotMutateTheRequest() async throws {
+        // Given a class-conformed request, a provider that refreshes its token, and a 401 then a 200
+        let provider = SpyAuthProvider(headers: [
+            HAuthorizationHeader(key: "Authorization", value: "Bearer token_1"),
+            HAuthorizationHeader(key: "Authorization", value: "Bearer token_2")
+        ])
+        Harbor.setAuthProvider(provider)
+        AuthStubProtocol.statusCodes = [401, 200]
+
+        let request = ClassAuthGetRequest(url: "https://example.com/secure")
+
+        // When
+        let response = await request.request()
+
+        // Then the retry succeeds with the refreshed header, the provider was asked twice,
+        // and the caller's request object kept its original (nil) headers
+        guard case .success = response else {
+            XCTFail("Expected success but got: \(response)")
+            return
+        }
+        XCTAssertEqual(provider.headerCallCount, 2)
+        XCTAssertEqual(AuthStubProtocol.receivedAuthorizations, ["Bearer token_1", "Bearer token_2"])
+        XCTAssertNil(request.headerParameters)
+    }
+
+    func test401WithoutNewHeaderFromProviderGivesUpWithAuthNeeded() async throws {
+        // Given a provider that has credentials once and none after the 401
+        let provider = SpyAuthProvider(headers: [
+            HAuthorizationHeader(key: "Authorization", value: "Bearer token_1"),
+            nil
+        ])
+        Harbor.setAuthProvider(provider)
+        AuthStubProtocol.statusCodes = [401]
+
+        let request = ClassAuthGetRequest(url: "https://example.com/secure")
+
+        // When
+        let response = await request.request()
+
+        // Then the flow ends with .authNeeded and authFailed was called exactly once
+        guard case .error(let error) = response, case .authNeeded = error else {
+            XCTFail("Expected .authNeeded but got: \(response)")
+            return
+        }
+        XCTAssertEqual(provider.headerCallCount, 2)
+        XCTAssertEqual(provider.authFailedCount, 1)
+    }
+
+    func testRequestWithoutCredentialsGoesOutWithoutAuthHeader() async throws {
+        // Given a provider without credentials
+        let provider = SpyAuthProvider(headers: [nil])
+        Harbor.setAuthProvider(provider)
+        AuthStubProtocol.statusCodes = [200]
+
+        let request = ClassAuthGetRequest(url: "https://example.com/secure")
+
+        // When
+        let response = await request.request()
+
+        // Then the request is sent without an authorization header
+        guard case .success = response else {
+            XCTFail("Expected success but got: \(response)")
+            return
+        }
+        XCTAssertEqual(AuthStubProtocol.receivedAuthorizations, [nil])
     }
 }

--- a/Tests/HarborTests/HarborRequestRetryTests.swift
+++ b/Tests/HarborTests/HarborRequestRetryTests.swift
@@ -84,7 +84,7 @@ private final class SpyAuthProvider: HAuthProviderProtocol {
     private(set) var headerCallCount = 0
     private(set) var authFailedCount = 0
 
-    func getAuthorizationHeader() async -> HAuthorizationHeader {
+    func getAuthorizationHeader() async -> HAuthorizationHeader? {
         headerCallCount += 1
         return HAuthorizationHeader(key: "Authorization", value: "Bearer token_\(headerCallCount)")
     }
@@ -111,6 +111,7 @@ private struct StubbedGetRequest: HGetRequestProtocol {
 }
 
 /// Request that needs auth but relies on the default `headerParameters`, which does not persist values.
+/// The authorization header is applied to the built URLRequest, so the flow works anyway.
 private struct HeaderlessAuthGetRequest: HGetRequestProtocol {
     typealias Model = MockModel
 
@@ -257,24 +258,27 @@ final class HarborRequestRetryTests: XCTestCase {
         }
     }
 
-    func testAuthInjectionFailsLoudlyWhenRequestCannotStoreHeaders() async throws {
+    func testAuthFlowWorksWhenRequestDoesNotPersistHeaders() async throws {
         // Given a valid provider and a request whose headerParameters are not persisted
         let provider = SpyAuthProvider()
         await Harbor.setAuthProvider(provider)
-        HRequestStubProtocol.mode = .status(200)
+        HRequestStubProtocol.mode = .status(401)
 
         let request = HeaderlessAuthGetRequest()
 
         // When
         let response = await request.request()
 
-        // Then the request fails before hitting the network instead of going out unauthenticated
-        guard case .error(let error) = response, case .malformedRequest = error else {
-            XCTFail("Expected .malformedRequest but got: \(response)")
+        // Then the request goes through the full auth flow (the header is applied to the
+        // URLRequest, not to the request type): 401, one refresh, then .authNeeded
+        XCTAssertEqual(HRequestStubProtocol.startLoadingCount, HRequestManager.maxAuthRetries + 1)
+        XCTAssertEqual(provider.headerCallCount, HRequestManager.maxAuthRetries + 1)
+        XCTAssertEqual(provider.authFailedCount, 1)
+
+        guard case .error(let error) = response, case .authNeeded = error else {
+            XCTFail("Expected .authNeeded but got: \(response)")
             return
         }
-        XCTAssertEqual(provider.headerCallCount, 1)
-        XCTAssertEqual(HRequestStubProtocol.startLoadingCount, 0)
     }
 
     // MARK: - URLSession Caching

--- a/Tests/HarborTests/HarborSHA256Tests.swift
+++ b/Tests/HarborTests/HarborSHA256Tests.swift
@@ -11,19 +11,19 @@ import XCTest
 final class HarborSHA256Tests: XCTestCase {
     func testSHA256EmptyData() {
         let data = Data()
-        let hash = SHA256.sha256(data: data)
+        let hash = SHA256.sha256Base64(data: data)
         XCTAssertEqual(hash, "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=", "Hash for empty data is incorrect")
     }
 
     func testSHA256HelloWorld() {
         let data = "Hello, world!".data(using: .utf8)!
-        let hash = SHA256.sha256(data: data)
+        let hash = SHA256.sha256Base64(data: data)
         XCTAssertEqual(hash, "MV9b23bQeMQ7isAGTkoBZGErH853yGk0W/yUx1iU7dM=", "Hash for 'Hello, world!' is incorrect")
     }
 
     func testSHA256LongString() {
         let data = String(repeating: "a", count: 1000).data(using: .utf8)!
-        let hash = SHA256.sha256(data: data)
+        let hash = SHA256.sha256Base64(data: data)
         XCTAssertEqual(hash, "Qe3s5C1j6Nm/UVqbppMuHCDLyfWl0TRkWttdsblzfqM=", "Hash for long string is incorrect")
     }
 }

--- a/Tests/HarborTests/HarborSecurityTests.swift
+++ b/Tests/HarborTests/HarborSecurityTests.swift
@@ -28,14 +28,14 @@ final class HarborSecurityTests: XCTestCase {
     override func setUp() async throws {
         Harbor.removeAllMocks()
         // Reset security configurations
-        Harbor.setSSlPinningKeys(nil)
+        Harbor.setSSLPinningKeys(nil)
         Harbor.clearMTLS()
     }
     
     override func tearDown() async throws {
         Harbor.removeAllMocks()
         // Reset security configurations
-        Harbor.setSSlPinningKeys(nil)
+        Harbor.setSSLPinningKeys(nil)
         Harbor.clearMTLS()
     }
     
@@ -46,7 +46,7 @@ final class HarborSecurityTests: XCTestCase {
         let testSHA256 = "ABC123456789ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF"
         
         // When
-        Harbor.setSSlPinningKeys([testSHA256])
+        Harbor.setSSLPinningKeys([testSHA256])
         
         // Then
         // SSL pinning should be configured (we can't directly test internal state)
@@ -57,10 +57,10 @@ final class HarborSecurityTests: XCTestCase {
     func testSSLPinningWithNilValue() async throws {
         // Given
         let testSHA256 = "ABC123456789ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF"
-        Harbor.setSSlPinningKeys([testSHA256])
+        Harbor.setSSLPinningKeys([testSHA256])
         
         // When
-        Harbor.setSSlPinningKeys(nil)
+        Harbor.setSSLPinningKeys(nil)
         
         // Then
         // SSL pinning should be disabled
@@ -70,7 +70,7 @@ final class HarborSecurityTests: XCTestCase {
     func testSSLPinningWithValidRequest() async throws {
         // Given
         let testSHA256 = "ABC123456789ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF"
-        Harbor.setSSlPinningKeys([testSHA256])
+        Harbor.setSSLPinningKeys([testSHA256])
         
         let mockResponse = TestSecureData(secret: "pinned-data")
         let jsonData = try JSONEncoder().encode(mockResponse)
@@ -98,10 +98,10 @@ final class HarborSecurityTests: XCTestCase {
         // Given
         let unwrappedP12URL = try XCTUnwrap(testP12URL, "certificate.p12 not found")
 
-        let mTLS = HmTLS(p12FileUrl: unwrappedP12URL, password: testPassword)
+        let mTLS = makeMTLS(url: unwrappedP12URL, password: testPassword)
 
         // When
-        try Harbor.setMTLS(mTLS)
+        try await Harbor.setMTLS(mTLS)
         
         // Then
         let identity = HConfig.shared.mTLSIdentity
@@ -112,8 +112,8 @@ final class HarborSecurityTests: XCTestCase {
         // Given
         let unwrappedP12URL = try XCTUnwrap(testP12URL, "certificate.p12 not found")
 
-        let mTLS = HmTLS(p12FileUrl: unwrappedP12URL, password: testPassword)
-        try Harbor.setMTLS(mTLS)
+        let mTLS = makeMTLS(url: unwrappedP12URL, password: testPassword)
+        try await Harbor.setMTLS(mTLS)
         
         // When
         Harbor.clearMTLS()
@@ -128,7 +128,7 @@ final class HarborSecurityTests: XCTestCase {
 
     func testMTLSExtractIdentityWithNonexistentFileThrowsFileNotFound() async throws {
         // Given
-        let mTLS = HmTLS(p12FileUrl: URL(fileURLWithPath: "/tmp/harbor-definitely-missing.p12"), password: testPassword)
+        let mTLS = makeMTLS(url: URL(fileURLWithPath: "/tmp/harbor-definitely-missing.p12"), password: testPassword)
 
         // When / Then
         XCTAssertThrowsError(try mTLS.extractIdentity()) { error in
@@ -139,7 +139,7 @@ final class HarborSecurityTests: XCTestCase {
     func testMTLSExtractIdentityWithWrongPasswordThrowsInvalidPassword() async throws {
         // Given
         let unwrappedP12URL = try XCTUnwrap(testP12URL, "certificate.p12 not found")
-        let mTLS = HmTLS(p12FileUrl: unwrappedP12URL, password: "wrong-password")
+        let mTLS = makeMTLS(url: unwrappedP12URL, password: "wrong-password")
 
         // When / Then
         XCTAssertThrowsError(try mTLS.extractIdentity()) { error in
@@ -149,10 +149,13 @@ final class HarborSecurityTests: XCTestCase {
 
     func testSetMTLSThrowsAndLeavesIdentityUnsetOnFailure() async throws {
         // Given
-        let mTLS = HmTLS(p12FileUrl: URL(fileURLWithPath: "/tmp/harbor-definitely-missing.p12"), password: testPassword)
+        let mTLS = makeMTLS(url: URL(fileURLWithPath: "/tmp/harbor-definitely-missing.p12"), password: testPassword)
 
         // Then
-        XCTAssertThrowsError(try Harbor.setMTLS(mTLS)) { error in
+        do {
+            try await Harbor.setMTLS(mTLS)
+            XCTFail("Expected setMTLS to throw")
+        } catch {
             XCTAssertEqual(error as? HMTLSError, .fileNotFound)
         }
         XCTAssertNil(HConfig.shared.mTLSIdentity)
@@ -161,10 +164,10 @@ final class HarborSecurityTests: XCTestCase {
     func testSetMTLSSucceedsAndConfiguresIdentity() async throws {
         // Given
         let unwrappedP12URL = try XCTUnwrap(testP12URL, "certificate.p12 not found")
-        let mTLS = HmTLS(p12FileUrl: unwrappedP12URL, password: testPassword)
+        let mTLS = makeMTLS(url: unwrappedP12URL, password: testPassword)
 
         // Then
-        XCTAssertNoThrow(try Harbor.setMTLS(mTLS))
+        try await Harbor.setMTLS(mTLS)
         XCTAssertNotNil(HConfig.shared.mTLSIdentity)
     }
     
@@ -173,11 +176,11 @@ final class HarborSecurityTests: XCTestCase {
     func testCombinedSSLPinningAndMTLS() async throws {
         // Given
         let testSHA256 = "ABC123456789ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF"
-        Harbor.setSSlPinningKeys([testSHA256])
+        Harbor.setSSLPinningKeys([testSHA256])
 
         let unwrappedP12URL = try XCTUnwrap(testP12URL, "certificate.p12 not found")
-        let mTLS = HmTLS(p12FileUrl: unwrappedP12URL, password: testPassword)
-        try Harbor.setMTLS(mTLS)
+        let mTLS = makeMTLS(url: unwrappedP12URL, password: testPassword)
+        try await Harbor.setMTLS(mTLS)
         
         let mockResponse = TestSecureData(secret: "fully-secured-data")
         let jsonData = try JSONEncoder().encode(mockResponse)
@@ -204,7 +207,7 @@ final class HarborSecurityTests: XCTestCase {
     func testSSLPinningFailure() async throws {
         // Given
         let testSHA256 = "INVALID_HASH"
-        Harbor.setSSlPinningKeys([testSHA256])
+        Harbor.setSSLPinningKeys([testSHA256])
         
         // Mock a SSL-related failure (using existing error types)
         let mock = HMock(request: SecureGetRequest.self, statusCode: 500, error: .noConnection)
@@ -232,8 +235,8 @@ final class HarborSecurityTests: XCTestCase {
         // Given
         let testP12URL = URL(fileURLWithPath: "/tmp/invalid.p12")
         let testPassword = "wrong-password"
-        let mTLS = HmTLS(p12FileUrl: testP12URL, password: testPassword)
-        try? Harbor.setMTLS(mTLS)
+        let mTLS = makeMTLS(url: testP12URL, password: testPassword)
+        try? await Harbor.setMTLS(mTLS)
         
         // Mock a certificate-related error (using existing error types)
         let mock = HMock(request: MTLSGetRequest.self, statusCode: 403)
@@ -262,7 +265,7 @@ final class HarborSecurityTests: XCTestCase {
     func testSPKIPinMatchesOpenSSLOutput() async throws {
         // Given
         let unwrappedP12URL = try XCTUnwrap(testP12URL, "certificate.p12 not found")
-        let mTLS = HmTLS(p12FileUrl: unwrappedP12URL, password: testPassword)
+        let mTLS = makeMTLS(url: unwrappedP12URL, password: testPassword)
         let identity = try mTLS.extractIdentity()
         let certificate = try XCTUnwrap(identity.certificateChain?.first)
 
@@ -321,7 +324,7 @@ final class HarborSecurityTests: XCTestCase {
     func testSPKIPinDiffersFromLegacyRawKeyHash() async throws {
         // Given
         let unwrappedP12URL = try XCTUnwrap(testP12URL, "certificate.p12 not found")
-        let mTLS = HmTLS(p12FileUrl: unwrappedP12URL, password: testPassword)
+        let mTLS = makeMTLS(url: unwrappedP12URL, password: testPassword)
         let identity = try mTLS.extractIdentity()
         let certificate = try XCTUnwrap(identity.certificateChain?.first)
 
@@ -329,7 +332,7 @@ final class HarborSecurityTests: XCTestCase {
         let pin = try XCTUnwrap(Harbor.computePin(for: certificate))
         let publicKey = try XCTUnwrap(SecCertificateCopyKey(certificate))
         let rawKeyData = try XCTUnwrap(SecKeyCopyExternalRepresentation(publicKey, nil) as Data?)
-        let legacyRawKeyHash = SHA256.sha256(data: rawKeyData)
+        let legacyRawKeyHash = SHA256.sha256Base64(data: rawKeyData)
 
         // Then
         // The SPKI pin must not match the legacy format (SHA-256 of the raw public key bytes)
@@ -355,7 +358,7 @@ final class HarborSecurityTests: XCTestCase {
 
     func testSetSSLPinningKeysWithMalformedPinDoesNotCrash() async {
         // Given / When: malformed pins should only log a warning, not crash
-        Harbor.setSSlPinningKeys(["INVALID_HASH", "X39uJq4Gmf5YvT9e7Q/Cc1DMepSL8aYi7hBI5l6qgO4="])
+        Harbor.setSSLPinningKeys(["INVALID_HASH", "X39uJq4Gmf5YvT9e7Q/Cc1DMepSL8aYi7hBI5l6qgO4="])
 
         // Then
         XCTAssertEqual(HConfig.shared.sslPinningKeys?.count, 2)
@@ -375,7 +378,7 @@ final class HarborSecurityTests: XCTestCase {
         let p12Data = try Data(contentsOf: unwrappedP12URL)
 
         // When
-        let pkcs12 = PKCS12(p12Data: p12Data, password: testPassword)
+        let pkcs12 = try PKCS12.parse(p12Data: p12Data, password: testPassword)
 
         // Then
         XCTAssertNotNil(pkcs12.identity)
@@ -383,10 +386,74 @@ final class HarborSecurityTests: XCTestCase {
         XCTAssertFalse(certChain.isEmpty)
     }
 
+    // MARK: - PKCS12 Failure Tests
+
+    func testPKCS12ParseWithWrongPasswordThrowsImportFailed() async throws {
+        // Given
+        let unwrappedP12URL = try XCTUnwrap(testP12URL, "certificate.p12 not found")
+        let p12Data = try Data(contentsOf: unwrappedP12URL)
+
+        // When / Then
+        XCTAssertThrowsError(try PKCS12.parse(p12Data: p12Data, password: "wrong-password")) { error in
+            guard let pkcs12Error = error as? PKCS12Error, case .importFailed(let status) = pkcs12Error else {
+                XCTFail("Expected PKCS12Error.importFailed but got: \(error)")
+                return
+            }
+            XCTAssertEqual(status, errSecAuthFailed)
+        }
+    }
+
+    func testPKCS12ParseWithCorruptDataThrows() async throws {
+        // Given
+        let corruptData = Data("not a p12 archive".utf8)
+
+        // When / Then
+        XCTAssertThrowsError(try PKCS12.parse(p12Data: corruptData, password: testPassword)) { error in
+            guard let pkcs12Error = error as? PKCS12Error, case .importFailed = pkcs12Error else {
+                XCTFail("Expected PKCS12Error.importFailed but got: \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: - HMTLS Password Handling Tests
+
+    func testMTLSDescriptionRedactsPassword() async throws {
+        // Given
+        let unwrappedP12URL = try XCTUnwrap(testP12URL, "certificate.p12 not found")
+        let mTLS = makeMTLS(url: unwrappedP12URL, password: testPassword)
+
+        // When
+        let description = String(describing: mTLS)
+        let interpolated = "\(mTLS)"
+
+        // Then
+        XCTAssertFalse(description.contains(testPassword))
+        XCTAssertFalse(interpolated.contains(testPassword))
+        XCTAssertTrue(description.contains("<redacted>"))
+        XCTAssertTrue(description.contains("certificate.p12"))
+    }
+
+    func testMTLSPasswordProviderIsCalledOncePerExtraction() async throws {
+        // Given
+        let unwrappedP12URL = try XCTUnwrap(testP12URL, "certificate.p12 not found")
+        let callCount = SendableCounter()
+        let mTLS = HMTLS(p12FileUrl: unwrappedP12URL) {
+            callCount.increment()
+            return "notapassword"
+        }
+
+        // When
+        _ = try mTLS.extractIdentity()
+
+        // Then
+        XCTAssertEqual(callCount.value, 1)
+    }
+
     func testMTLSIdentityIncludesCertificateChain() async throws {
         // Given
         let unwrappedP12URL = try XCTUnwrap(testP12URL, "certificate.p12 not found")
-        let mTLS = HmTLS(p12FileUrl: unwrappedP12URL, password: testPassword)
+        let mTLS = makeMTLS(url: unwrappedP12URL, password: testPassword)
 
         // When
         let identity = try mTLS.extractIdentity()
@@ -394,6 +461,31 @@ final class HarborSecurityTests: XCTestCase {
         // Then
         let certChain = try XCTUnwrap(identity.certificateChain)
         XCTAssertFalse(certChain.isEmpty)
+    }
+}
+
+// MARK: - Test Helpers
+
+/// Builds an mTLS configuration with a fixed password exposed through the provider closure.
+private func makeMTLS(url: URL, password: String) -> HMTLS {
+    HMTLS(p12FileUrl: url, passwordProvider: { password })
+}
+
+/// A lock-protected counter that can be shared with a `@Sendable` closure.
+private final class SendableCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _value
+    }
+
+    func increment() {
+        lock.lock()
+        _value += 1
+        lock.unlock()
     }
 }
 

--- a/Tests/HarborTests/HarborSecurityTests.swift
+++ b/Tests/HarborTests/HarborSecurityTests.swift
@@ -131,7 +131,10 @@ final class HarborSecurityTests: XCTestCase {
         let mTLS = makeMTLS(url: URL(fileURLWithPath: "/tmp/harbor-definitely-missing.p12"), password: testPassword)
 
         // When / Then
-        XCTAssertThrowsError(try mTLS.extractIdentity()) { error in
+        do {
+            _ = try await mTLS.extractIdentity()
+            XCTFail("Expected extractIdentity to throw")
+        } catch {
             XCTAssertEqual(error as? HMTLSError, .fileNotFound)
         }
     }
@@ -142,8 +145,25 @@ final class HarborSecurityTests: XCTestCase {
         let mTLS = makeMTLS(url: unwrappedP12URL, password: "wrong-password")
 
         // When / Then
-        XCTAssertThrowsError(try mTLS.extractIdentity()) { error in
+        do {
+            _ = try await mTLS.extractIdentity()
+            XCTFail("Expected extractIdentity to throw")
+        } catch {
             XCTAssertEqual(error as? HMTLSError, .invalidPassword)
+        }
+    }
+
+    func testMTLSExtractIdentityWithThrowingPasswordProviderThrowsPasswordProviderFailed() async throws {
+        // Given a provider that fails to supply the password
+        let unwrappedP12URL = try XCTUnwrap(testP12URL, "certificate.p12 not found")
+        let mTLS = HMTLS(p12FileUrl: unwrappedP12URL) { throw URLError(.cannotLoadFromNetwork) }
+
+        // When / Then
+        do {
+            _ = try await mTLS.extractIdentity()
+            XCTFail("Expected extractIdentity to throw")
+        } catch {
+            XCTAssertEqual(error as? HMTLSError, .passwordProviderFailed)
         }
     }
 
@@ -266,7 +286,7 @@ final class HarborSecurityTests: XCTestCase {
         // Given
         let unwrappedP12URL = try XCTUnwrap(testP12URL, "certificate.p12 not found")
         let mTLS = makeMTLS(url: unwrappedP12URL, password: testPassword)
-        let identity = try mTLS.extractIdentity()
+        let identity = try await mTLS.extractIdentity()
         let certificate = try XCTUnwrap(identity.certificateChain?.first)
 
         // When
@@ -325,7 +345,7 @@ final class HarborSecurityTests: XCTestCase {
         // Given
         let unwrappedP12URL = try XCTUnwrap(testP12URL, "certificate.p12 not found")
         let mTLS = makeMTLS(url: unwrappedP12URL, password: testPassword)
-        let identity = try mTLS.extractIdentity()
+        let identity = try await mTLS.extractIdentity()
         let certificate = try XCTUnwrap(identity.certificateChain?.first)
 
         // When
@@ -444,7 +464,7 @@ final class HarborSecurityTests: XCTestCase {
         }
 
         // When
-        _ = try mTLS.extractIdentity()
+        _ = try await mTLS.extractIdentity()
 
         // Then
         XCTAssertEqual(callCount.value, 1)
@@ -456,7 +476,7 @@ final class HarborSecurityTests: XCTestCase {
         let mTLS = makeMTLS(url: unwrappedP12URL, password: testPassword)
 
         // When
-        let identity = try mTLS.extractIdentity()
+        let identity = try await mTLS.extractIdentity()
 
         // Then
         let certChain = try XCTUnwrap(identity.certificateChain)

--- a/skill/harbor/SKILL.md
+++ b/skill/harbor/SKILL.md
@@ -104,11 +104,14 @@ await Harbor.setAuthProvider(MyAuthProvider())
 await Harbor.setDefaultHeaderParameters(["X-API-Key": "secret"])
 
 // Enable SSL Pinning
-await Harbor.setSSlPinningKeys(["sha256hash1", "sha256hash2"])
+await Harbor.setSSLPinningKeys(["sha256hash1", "sha256hash2"])
 
-// Configure mTLS
-let mtls = HmTLS(p12FileUrl: certUrl, password: "password")
-await Harbor.setMTLS(mtls)
+// Enable SSL Pinning only for specific hosts
+await Harbor.setSSLPinningKeys(["sha256hash1"], forHosts: ["api.example.com"])
+
+// Configure mTLS (the password is requested on demand, not retained)
+let mtls = HMTLS(p12FileUrl: certUrl) { "password" }
+try await Harbor.setMTLS(mtls)
 
 // Set default cache type
 await Harbor.setDefaultCacheType(.custom(HCache.Configuration(expirationTime: .oneDay)))
@@ -277,7 +280,7 @@ See the `examples/` directory for:
 
 ### Configuring Authentication
 1. Implement `HAuthProviderProtocol`
-2. Return the current header in `getAuthorizationHeader()` (an `HAuthorizationHeader` key-value pair)
+2. Return the current header in `getAuthorizationHeader()` (an `HAuthorizationHeader` key-value pair, or `nil` when no credentials are available — the request then goes out without an auth header)
 3. Handle credential failures in `authFailed()` (called after a 401 when no new header is available; Harbor retries automatically when the header changes)
 4. Set globally: `await Harbor.setAuthProvider(provider)`
 

--- a/skill/harbor/security.md
+++ b/skill/harbor/security.md
@@ -117,7 +117,8 @@ struct MyApp: App {
                 }
                 
                 // Configure mTLS; the password is read from secure storage on demand
-                let mtls = HMTLS(p12FileUrl: certUrl) { try loadCertificatePassword() }
+                let certificatePassword = loadCertificatePassword()
+                let mtls = HMTLS(p12FileUrl: certUrl) { certificatePassword }
                 try await Harbor.setMTLS(mtls)
                 
                 print("mTLS configured successfully")
@@ -169,7 +170,7 @@ case .error(let error):
 let mtls = HMTLS(p12FileUrl: url) { "hardcoded-password" }
 
 // ✅ Good - read from Keychain on demand; the password is not retained by HMTLS
-let mtls = HMTLS(p12FileUrl: url) { try KeychainManager.getCertificatePassword() }
+let mtls = HMTLS(p12FileUrl: url) { KeychainManager.certificatePassword }
 ```
 
 2. **Certificate Rotation**
@@ -775,7 +776,10 @@ func testMTLS() async {
     }
     
     let response = await MTLSTest().request()
-    XCTAssertTrue(response.isSuccess)
+    guard case .success = response else {
+        XCTFail("Expected success but got: \(response)")
+        return
+    }
 }
 ```
 
@@ -786,12 +790,17 @@ func testSSLPinning() async {
     // Test with correct key
     await Harbor.setSSLPinningKeys(["correct-hash"])
     let response1 = await SecureRequest().request()
-    XCTAssertTrue(response1.isSuccess)
+    guard case .success = response1 else {
+        XCTFail("Expected success but got: \(response1)")
+        return
+    }
     
     // Test with wrong key (should fail)
     await Harbor.setSSLPinningKeys(["wrong-hash"])
     let response2 = await SecureRequest().request()
-    XCTAssertTrue(response2.isError)
+    if case .success = response2 {
+        XCTFail("Expected pinning failure but got success")
+    }
 }
 ```
 
@@ -809,7 +818,10 @@ func testAuthentication() async {
     }
     
     let response = await AuthRequest().request()
-    XCTAssertTrue(response.isSuccess)
+    guard case .success = response else {
+        XCTFail("Expected success but got: \(response)")
+        return
+    }
 }
 ```
 

--- a/skill/harbor/security.md
+++ b/skill/harbor/security.md
@@ -27,11 +27,11 @@ Mutual TLS extends standard TLS by requiring both the server and client to authe
 ```swift
 struct HMTLS: Sendable, CustomStringConvertible {
     let p12FileUrl: URL
-    let passwordProvider: @Sendable () -> String
+    let passwordProvider: @Sendable () async throws -> String
 }
 ```
 
-The password is requested through `passwordProvider` once, when the identity is extracted; it is not retained by the configuration value. The `CustomStringConvertible` description always redacts the password. The older `HmTLS` spelling and the `init(p12FileUrl:password:)` initializer are deprecated.
+The password is requested through `passwordProvider` once, when the identity is extracted; it is not retained by the configuration value. The async signature accommodates password sources that are themselves asynchronous, such as keychain wrappers, biometric prompts or remote vaults; a provider failure surfaces as `HMTLSError.passwordProviderFailed`. The `CustomStringConvertible` description always redacts the password. The older `HmTLS` spelling and the `init(p12FileUrl:password:)` initializer are deprecated.
 
 ### Setting Up mTLS
 

--- a/skill/harbor/security.md
+++ b/skill/harbor/security.md
@@ -25,11 +25,13 @@ Mutual TLS extends standard TLS by requiring both the server and client to authe
 **Location**: `Sources/Harbor/Request/HmTLS.swift`
 
 ```swift
-struct HmTLS: Sendable {
+struct HMTLS: Sendable, CustomStringConvertible {
     let p12FileUrl: URL
-    let password: String
+    let passwordProvider: @Sendable () -> String
 }
 ```
+
+The password is requested through `passwordProvider` once, when the identity is extracted; it is not retained by the configuration value. The `CustomStringConvertible` description always redacts the password. The older `HmTLS` spelling and the `init(p12FileUrl:password:)` initializer are deprecated.
 
 ### Setting Up mTLS
 
@@ -55,8 +57,8 @@ Task {
         return
     }
     
-    let mtls = HmTLS(p12FileUrl: p12Url, password: "your-certificate-password")
-    await Harbor.setMTLS(mtls)
+    let mtls = HMTLS(p12FileUrl: p12Url) { "your-certificate-password" }
+    try await Harbor.setMTLS(mtls)
 }
 ```
 
@@ -86,10 +88,10 @@ Harbor internally handles:
 
 **Error Handling:**
 ```swift
-// Harbor logs errors if certificate loading fails
-// Check console for messages like:
-// "Failed to load PKCS12 file"
-// "Failed to import PKCS12 data"
+// PKCS12.parse throws a typed PKCS12Error and logs failures when logging is enabled:
+// - .importFailed(status): SecPKCS12Import rejected the archive (errSecAuthFailed = wrong password)
+// - .malformedContents: the imported items could not be read
+// Harbor.setMTLS surfaces these as HMTLSError (fileNotFound, invalidPassword, invalidP12Format, noIdentity)
 ```
 
 ### Example: Complete Setup
@@ -114,12 +116,9 @@ struct MyApp: App {
                     throw NSError(domain: "Certificate not found", code: 1)
                 }
                 
-                // Read password from secure storage (example)
-                let password = try loadCertificatePassword()
-                
-                // Configure mTLS
-                let mtls = HmTLS(p12FileUrl: certUrl, password: password)
-                await Harbor.setMTLS(mtls)
+                // Configure mTLS; the password is read from secure storage on demand
+                let mtls = HMTLS(p12FileUrl: certUrl) { try loadCertificatePassword() }
+                try await Harbor.setMTLS(mtls)
                 
                 print("mTLS configured successfully")
             } catch {
@@ -167,19 +166,18 @@ case .error(let error):
 ```swift
 // Don't hardcode passwords
 // ❌ Bad
-let mtls = HmTLS(p12FileUrl: url, password: "hardcoded-password")
+let mtls = HMTLS(p12FileUrl: url) { "hardcoded-password" }
 
-// ✅ Good - use Keychain
-let password = try KeychainManager.getCertificatePassword()
-let mtls = HmTLS(p12FileUrl: url, password: password)
+// ✅ Good - read from Keychain on demand; the password is not retained by HMTLS
+let mtls = HMTLS(p12FileUrl: url) { try KeychainManager.getCertificatePassword() }
 ```
 
 2. **Certificate Rotation**
 ```swift
 // Support certificate updates
-func updateClientCertificate(newCertUrl: URL, password: String) async {
-    let mtls = HmTLS(p12FileUrl: newCertUrl, password: password)
-    await Harbor.setMTLS(mtls)
+func updateClientCertificate(newCertUrl: URL, password: String) async throws {
+    let mtls = HMTLS(p12FileUrl: newCertUrl) { password }
+    try await Harbor.setMTLS(mtls)
 }
 ```
 
@@ -219,7 +217,7 @@ SSL Pinning uses SHA256 hashes of the certificate's **SubjectPublicKeyInfo (SPKI
 ```swift
 // Compute the pin from any SecCertificate (e.g. extracted from a P12 or a server trust)
 if let pin = await Harbor.computePin(for: certificate) {
-    await Harbor.setSSlPinningKeys([pin])
+    await Harbor.setSSLPinningKeys([pin])
 }
 ```
 
@@ -246,7 +244,7 @@ openssl pkey -pubin -in publickey.pem -outform DER | \
 3. Export certificate
 4. Use OpenSSL commands above
 
-> **Note**: Pins must be valid base64-encoded SHA-256 hashes (32 bytes, 44 chars with `=` padding or 43 without). Malformed pins log a warning when calling `setSSlPinningKeys` and are ignored during validation.
+> **Note**: Pins must be valid base64-encoded SHA-256 hashes (32 bytes, 44 chars with `=` padding or 43 without). Malformed pins log a warning when calling `setSSLPinningKeys` and are ignored during validation.
 
 ### Setting Up SSL Pinning
 
@@ -255,7 +253,7 @@ openssl pkey -pubin -in publickey.pem -outform DER | \
 ```swift
 // In app initialization
 let publicKeyHash = "YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg="
-await Harbor.setSSlPinningKeys([publicKeyHash])
+await Harbor.setSSLPinningKeys([publicKeyHash])
 ```
 
 #### Multiple Keys (Recommended)
@@ -270,7 +268,19 @@ let primaryKey = "YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg="
 let backupKey = "GNKGcGj1ue3yRYvqr9t/lz2nkzMU5VZK3QBILcvPJ8U="
 let rotationKey = "X2aKNRD8aZ4hJ+5tT6uAzYa1WePqC4p7k9mKp2kYvHg="
 
-await Harbor.setSSlPinningKeys([primaryKey, backupKey, rotationKey])
+await Harbor.setSSLPinningKeys([primaryKey, backupKey, rotationKey])
+```
+
+#### Per-Host Pinning
+
+Pins can be scoped to specific hosts with `setSSLPinningKeys(_:forHosts:)`. Challenges from the configured hosts are validated against their pins; any other host falls back to the global pins or, when none are set, to the default URLSession handling:
+
+```swift
+// Only api.example.com is pinned; every other host uses default handling
+await Harbor.setSSLPinningKeys([apiKey, apiBackupKey], forHosts: ["api.example.com"])
+
+// Stop pinning a host
+await Harbor.setSSLPinningKeys(nil, forHosts: ["api.example.com"])
 ```
 
 ### How SSL Pinning Works
@@ -330,7 +340,7 @@ class AppConfiguration {
                 // Next rotation (valid from Jan 2027)
                 "X2aKNRD8aZ4hJ+5tT6uAzYa1WePqC4p7k9mKp2kYvHg="
             ]
-            await Harbor.setSSlPinningKeys(apiKeys)
+            await Harbor.setSSLPinningKeys(apiKeys)
             
             print("SSL Pinning configured with \(apiKeys.count) keys")
         }
@@ -361,7 +371,7 @@ case .error(let error):
 1. **Pin Multiple Keys**
 ```swift
 // Pin current + future certificates
-await Harbor.setSSlPinningKeys([
+await Harbor.setSSLPinningKeys([
     currentCertHash,
     nextCertHash,
     backupCertHash
@@ -385,7 +395,7 @@ struct PinningConfig: Codable {
 
 // Fetch and update
 if let config = await fetchPinningConfig() {
-    await Harbor.setSSlPinningKeys(config.keys)
+    await Harbor.setSSLPinningKeys(config.keys)
 }
 ```
 
@@ -393,10 +403,10 @@ if let config = await fetchPinningConfig() {
 ```swift
 #if DEBUG
 // Allow network debugging tools in development
-// await Harbor.setSSlPinningKeys([])
+// await Harbor.setSSLPinningKeys([])
 #else
 // Enable pinning in production
-await Harbor.setSSlPinningKeys(productionKeys)
+await Harbor.setSSLPinningKeys(productionKeys)
 #endif
 ```
 
@@ -444,7 +454,7 @@ await Harbor.setLogSensitiveHeaders(true)
 
 ```swift
 protocol HAuthProviderProtocol: Sendable {
-    func getAuthorizationHeader() async -> HAuthorizationHeader
+    func getAuthorizationHeader() async -> HAuthorizationHeader?
     func authFailed() async
 }
 
@@ -454,7 +464,7 @@ struct HAuthorizationHeader: Sendable, Equatable {
 }
 ```
 
-Harbor calls `getAuthorizationHeader()` before every request with `needsAuth = true` and sets the returned key-value pair as a header. On a 401 response, Harbor asks for the header again: if the value changed (e.g. the provider refreshed its token), the request is retried automatically; otherwise `authFailed()` is called and the request fails with `.authNeeded`. There is no built-in expiration check — return the freshest header you have from `getAuthorizationHeader()` and use `authFailed()` to trigger re-authentication.
+Harbor calls `getAuthorizationHeader()` before every request with `needsAuth = true` and sets the returned key-value pair as a header; a `nil` header means no credentials are available and the request is sent without an authorization header. On a 401 response, Harbor asks for the header again: if the value changed (e.g. the provider refreshed its token), the request is retried automatically; if it is unchanged or `nil`, `authFailed()` is called and the request fails with `.authNeeded`. There is no built-in expiration check — return the freshest header you have from `getAuthorizationHeader()` and use `authFailed()` to trigger re-authentication.
 
 ### Implementing Auth Provider
 
@@ -464,8 +474,9 @@ Harbor calls `getAuthorizationHeader()` before every request with `needsAuth = t
 final class TokenAuthProvider: HAuthProviderProtocol, @unchecked Sendable {
     private var accessToken: String?
 
-    func getAuthorizationHeader() async -> HAuthorizationHeader {
-        HAuthorizationHeader(key: "Authorization", value: "Bearer \(accessToken ?? "")")
+    func getAuthorizationHeader() async -> HAuthorizationHeader? {
+        guard let accessToken else { return nil }
+        return HAuthorizationHeader(key: "Authorization", value: "Bearer \(accessToken)")
     }
 
     func authFailed() async {
@@ -502,12 +513,13 @@ final class OAuth2AuthProvider: HAuthProviderProtocol, @unchecked Sendable {
         self.tokenEndpoint = tokenEndpoint
     }
 
-    func getAuthorizationHeader() async -> HAuthorizationHeader {
+    func getAuthorizationHeader() async -> HAuthorizationHeader? {
         // Refresh proactively when the token is about to expire
         if isTokenExpired() {
             try? await refreshTokens()
         }
-        return HAuthorizationHeader(key: "Authorization", value: "Bearer \(accessToken ?? "")")
+        guard let accessToken else { return nil }
+        return HAuthorizationHeader(key: "Authorization", value: "Bearer \(accessToken)")
     }
 
     func authFailed() async {
@@ -572,7 +584,7 @@ final class APIKeyAuthProvider: HAuthProviderProtocol, @unchecked Sendable {
         self.headerName = headerName
     }
 
-    func getAuthorizationHeader() async -> HAuthorizationHeader {
+    func getAuthorizationHeader() async -> HAuthorizationHeader? {
         HAuthorizationHeader(key: headerName, value: apiKey)
     }
 
@@ -618,7 +630,7 @@ Check if auth provider is set
     └─ Yes
         │
         ▼
-    Call getAuthorizationHeader() → Add header → Execute request
+    Call getAuthorizationHeader() → Add header (if any) → Execute request
         │
         ▼
 Request completes
@@ -633,7 +645,7 @@ Request completes
         ├─ Header changed (provider refreshed credentials)
         │   → Retry request once with the new header
         │
-        └─ Header unchanged
+        └─ Header unchanged or nil
             → Call authFailed() → Return authNeeded error
 ```
 
@@ -701,11 +713,12 @@ default:
 ```swift
 // Refresh the token inside getAuthorizationHeader() when it is close to expiring,
 // so Harbor always gets a valid header
-func getAuthorizationHeader() async -> HAuthorizationHeader {
+func getAuthorizationHeader() async -> HAuthorizationHeader? {
     if tokenIsCloseToExpiring {
         try? await refreshTokens()
     }
-    return HAuthorizationHeader(key: "Authorization", value: "Bearer \(accessToken ?? "")")
+    guard let accessToken else { return nil }
+    return HAuthorizationHeader(key: "Authorization", value: "Bearer \(accessToken)")
 }
 ```
 
@@ -723,20 +736,20 @@ func logout() async {
 ### mTLS + SSL Pinning + Auth
 
 ```swift
-func configureFullSecurity() async {
+func configureFullSecurity() async throws {
     // 1. Configure mTLS
     guard let certUrl = Bundle.main.url(forResource: "client", withExtension: "p12") else {
         return
     }
-    let mtls = HmTLS(p12FileUrl: certUrl, password: getSecurePassword())
-    await Harbor.setMTLS(mtls)
+    let mtls = HMTLS(p12FileUrl: certUrl) { getSecurePassword() }
+    try await Harbor.setMTLS(mtls)
     
     // 2. Configure SSL Pinning
     let pinnedKeys = [
         "YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg=",
         "GNKGcGj1ue3yRYvqr9t/lz2nkzMU5VZK3QBILcvPJ8U="
     ]
-    await Harbor.setSSlPinningKeys(pinnedKeys)
+    await Harbor.setSSLPinningKeys(pinnedKeys)
     
     // 3. Configure Authentication
     let authProvider = OAuth2AuthProvider(
@@ -771,12 +784,12 @@ func testMTLS() async {
 ```swift
 func testSSLPinning() async {
     // Test with correct key
-    await Harbor.setSSlPinningKeys(["correct-hash"])
+    await Harbor.setSSLPinningKeys(["correct-hash"])
     let response1 = await SecureRequest().request()
     XCTAssertTrue(response1.isSuccess)
     
     // Test with wrong key (should fail)
-    await Harbor.setSSlPinningKeys(["wrong-hash"])
+    await Harbor.setSSLPinningKeys(["wrong-hash"])
     let response2 = await SecureRequest().request()
     XCTAssertTrue(response2.isError)
 }


### PR DESCRIPTION
## Summary

Security hardening across mTLS, SSL pinning, authentication, caching, and session configuration.

### Library

- **Auth injection no longer mutates the caller's request** — the authorization header is carried alongside the request and applied to the built `URLRequest`, so class-conformed requests are never mutated behind the caller's back (both the initial injection and the 401 refresh retry).
- **Optional authorization header** — `HAuthProviderProtocol.getAuthorizationHeader()` now returns `HAuthorizationHeader?`; providers without a token return `nil` and the request goes out unauthenticated instead of sending an empty credential.
- **401 handling is credential-aware** — a 401 on a request that opted out of auth (`needsAuth == false`) gives up with `.authNeeded` without consulting the provider or firing `authFailed()`; the refresh retry only happens when the provider issues a different header.
- **`Vary: Authorization` is keyed per credential** — the authorization header now participates in the custom cache's vary-key computation, so entries stored under one credential are never served to another. Cache lookups (`cache()`, `saveCache`, stale-on-error) auto-resolve the header from the configured provider when it isn't supplied explicitly. The offline stale-cache path tries the lookup without consulting the provider first, so credential-less entries are served without triggering provider (potentially network) work while offline.
- **mTLS password is no longer persisted** — `HMTLS` takes a `passwordProvider: @Sendable () async throws -> String` called once during identity extraction; the password never sits on the heap as a stored property and descriptions redact it. The async signature accommodates password sources that are themselves asynchronous (keychain wrappers, biometric prompts, remote vaults); provider failures surface as `HMTLSError.passwordProviderFailed`.
- **PKCS12 parsing is explicit about failure** — `PKCS12.parse(...) throws` with a typed `PKCS12Error` replaces the partially-initialized-object init; all `SecPKCS12Import` failure statuses are logged in debug builds (via `SecCopyErrorMessageString`) when logging is enabled, not only `errSecAuthFailed`.
- **Per-host SSL pinning** — `Harbor.setSSLPinningKeys(_:forHosts:)` scopes pins to specific hosts; challenges from unconfigured hosts receive default handling instead of being cancelled. Host matching is normalized (case-insensitive, trailing root-label dot stripped) and empty host keys are rejected with a warning. Trust evaluation runs asynchronously off the session's serial delegate queue (`SecTrustEvaluateAsyncWithError`) so a slow evaluation never stalls other connections, and pin matching re-validates the evaluated chain before comparing pins.
- **Naming cleanup** — new `HMTLS` type and `setSSLPinningKeys` (fixing the `setSSlPinningKeys` casing typo); old names kept as deprecated shims. SHA-256 helpers renamed to `sha256Base64` / `sha256Data` / `sha256Hex` with deprecated aliases.
- **`Harbor.setMTLS` is now `async throws`** — the p12 file read runs off the actor instead of blocking it.
- **Configurable cookie handling** — `HConfig.httpShouldHandleCookies` (default `false`) replaces the hardcoded value and is applied both per-request and at the session level (`httpShouldSetCookies`), with session invalidation when the value changes.

### Tests

- mTLS delegate happy path: real identity extracted from the p12 fixture answers a client-certificate challenge with `.useCredential`.
- SSL pinning success, mismatch, and untrusted-chain paths via the internal `matchPins(serverTrust:sslPinningKeys:)` seam; per-host precedence, passthrough, and host normalization covered.
- Spy auth provider covering the 401 flow: give-up path calls `authFailed()` exactly once; refresh path retries with the new header and succeeds; opted-out requests never consult the provider.
- Class-conformed request aliasing: original `headerParameters` untouched after auth injection and after the 401 retry.
- `Vary: Authorization` cache tests: different credentials never share entries; manual `cache()` calls resolve the header from the provider automatically; missing provider degrades gracefully.
- 310 package tests, all green.

### Example app

- Adopted the new security APIs (optional auth headers, `HMTLS` with password provider, per-host pinning).
- The auth-refresh demo now runs the real flow against a local `URLProtocol` stub: expired token → 401 → refresh → automatic retry succeeds.
- The mTLS demo actually loads the bundled `certificate.p12` and surfaces typed errors; the demo endpoint is documented.
- The SSL pinning demo computes the pin at runtime from the live server certificate instead of hardcoding a placeholder hash.

### Docs

- `README.md`, `skill/harbor/security.md`, `skill/harbor/SKILL.md` and `CHANGELOG.md` updated for the new APIs and deprecations.

### Breaking changes

- `HAuthProviderProtocol.getAuthorizationHeader()` → `HAuthorizationHeader?`
- `HmTLS` → deprecated in favor of `HMTLS` (async, throwing password provider init)
- `Harbor.setMTLS` → `async throws`
- `PKCS12` init → `PKCS12.parse(...) throws`
- Internally built sessions now set `httpShouldSetCookies` from `Harbor.setHTTPShouldHandleCookies(_:)`; with the default `false`, `Set-Cookie` responses are not stored in the shared cookie storage unless cookie handling is enabled


